### PR TITLE
ci: setup code coverage pipeline

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "4.8.0",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -65,7 +65,7 @@ jobs:
     inputs:
       command: 'test'
       arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --nologo --no-restore --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
-      publishTestResults: true
+      publishTestResults: false
   # Generate
   - task: DotNetCoreCLI@2
     displayName: 'Generate Report'

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -52,6 +52,7 @@ jobs:
       restoreArguments: '$(Solution_File)'
       feedsToUse: 'config'
       nugetConfigPath: '$(NuGet_Configuration_File)'
+      verbosityRestore: 'Minimal'
   - task: DotNetCoreCLI@2
     displayName: 'Install .NET Tools'
     inputs:
@@ -63,7 +64,7 @@ jobs:
     displayName: 'Collect Code Coverage'
     inputs:
       command: 'test'
-      arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --no-restore --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
+      arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --nologo --no-restore --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
       publishTestResults: false
   # Generate
   - task: DotNetCoreCLI@2

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -23,14 +23,14 @@ jobs:
     vmImage: $(imageName)
 
   variables:
-    NuGet_Configuration_File: './source/nuget.config'
-    Solution_File: './source/F0.Analyzers.sln'
-    Test_Results_Directory: './source/TestResults'
-    Runsettings_File: './source/test/coverlet.runsettings'
-    Coverage_Reports_Glob: './source/TestResults/**/coverage.cobertura.xml'
-    Report_Target_Directory: './source/TestResults/coveragereport'
+    NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/source/nuget.config'
+    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.sln'
+    Test_Results_Directory: '$(System.DefaultWorkingDirectory)/source/TestResults'
+    Runsettings_File: '$(System.DefaultWorkingDirectory)/source/test/coverlet.runsettings'
+    Coverage_Reports_Glob: '$(System.DefaultWorkingDirectory)/source/TestResults/**/coverage.cobertura.xml'
+    Report_Target_Directory: '$(System.DefaultWorkingDirectory)/source/TestResults/coveragereport'
     Report_Types: 'Cobertura'
-    Report_Target_File: './source/TestResults/coveragereport/Cobertura.xml'
+    Report_Target_File: '$(System.DefaultWorkingDirectory)/source/TestResults/coveragereport/Cobertura.xml'
 
   steps:
   # Init

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -23,8 +23,9 @@ jobs:
     vmImage: $(imageName)
 
   variables:
-    NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/source/nuget.config'
+    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.sln'
     Solution_Filter_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.Core.slnf'
+    NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/source/nuget.config'
     Test_Results_Directory: '$(System.DefaultWorkingDirectory)/source/TestResults'
     Runsettings_File: '$(System.DefaultWorkingDirectory)/source/test/coverlet.runsettings'
     Coverage_Reports_Glob: '$(System.DefaultWorkingDirectory)/source/TestResults/**/coverage.cobertura.xml'
@@ -45,6 +46,13 @@ jobs:
       performMultiLevelLookup: true
   # Restore
   - task: DotNetCoreCLI@2
+    displayName: 'Restore Dependencies'
+    inputs:
+      command: 'restore'
+      restoreArguments: '$(Solution_File)'
+      feedsToUse: 'config'
+      nugetConfigPath: '$(NuGet_Configuration_File)'
+  - task: DotNetCoreCLI@2
     displayName: 'Install .NET Tools'
     inputs:
       command: 'custom'
@@ -55,7 +63,7 @@ jobs:
     displayName: 'Collect Code Coverage'
     inputs:
       command: 'test'
-      arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
+      arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --no-restore --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
       publishTestResults: false
   # Generate
   - task: DotNetCoreCLI@2

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -18,7 +18,7 @@ jobs:
   strategy:
     matrix:
       ubuntu:
-        imageName: 'ubuntu-latest'
+        imageName: 'windows-2019'
   pool:
     vmImage: $(imageName)
 

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -1,0 +1,61 @@
+name: 'Code Coverage'
+
+trigger:
+  branches:
+    include:
+    - master
+pr:
+  branches:
+    include:
+    - master
+
+variables:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+- job: 'code_coverage'
+  strategy:
+    matrix:
+      ubuntu:
+        imageName: 'ubuntu-latest'
+  pool:
+    vmImage: $(imageName)
+
+  variables:
+    NuGet_Configuration_File: './source/nuget.config'
+    Solution_File: './source/F0.Analyzers.sln'
+    Test_Results_Directory: './source/TestResults'
+    Runsettings_File: './source/test/coverlet.runsettings'
+    Coverage_Reports_Glob: './source/TestResults/**/coverage.cobertura.xml'
+    Report_Target_Directory: './source/TestResults/coveragereport'
+    Report_Types: 'Cobertura'
+    Report_Target_File: './source/TestResults/coveragereport/Cobertura.xml'
+
+  steps:
+  # Init
+  - checkout: self
+    displayName: 'Checkout'
+    fetchDepth: 1
+  - task: UseDotNet@2
+    displayName: 'Setup .NET Core SDK'
+    inputs:
+      packageType: 'sdk'
+      useGlobalJson: true
+      performMultiLevelLookup: true
+  # Restore
+  - script: dotnet tool restore --configfile $(NuGet_Configuration_File)
+    displayName: 'Install .NET Tools'
+  # Collect
+  - script: dotnet test $(Solution_File) --collect:"XPlat Code Coverage" --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)
+    displayName: 'Collect Code Coverage'
+  # Generate
+  - script: dotnet tool run reportgenerator "-reports:$(Coverage_Reports_Glob)" "-targetdir:$(Report_Target_Directory)" -reporttypes:$(Report_Types)
+    displayName: 'Generate Report'
+  # Report
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish Results'
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Report_Target_File)'
+      failIfCoverageEmpty: true

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -17,14 +17,14 @@ jobs:
 - job: 'code_coverage'
   strategy:
     matrix:
-      ubuntu:
+      windows:
         imageName: 'windows-2019'
   pool:
     vmImage: $(imageName)
 
   variables:
     NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/source/nuget.config'
-    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.sln'
+    Solution_Filter_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.Core.slnf'
     Test_Results_Directory: '$(System.DefaultWorkingDirectory)/source/TestResults'
     Runsettings_File: '$(System.DefaultWorkingDirectory)/source/test/coverlet.runsettings'
     Coverage_Reports_Glob: '$(System.DefaultWorkingDirectory)/source/TestResults/**/coverage.cobertura.xml'
@@ -55,7 +55,7 @@ jobs:
     displayName: 'Collect Code Coverage'
     inputs:
       command: 'test'
-      arguments: '$(Solution_File) --collect:"XPlat Code Coverage" --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
+      arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
       publishTestResults: false
   # Generate
   - task: DotNetCoreCLI@2

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -65,7 +65,7 @@ jobs:
     inputs:
       command: 'test'
       arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --nologo --no-restore --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
-      publishTestResults: false
+      publishTestResults: true
   # Generate
   - task: DotNetCoreCLI@2
     displayName: 'Generate Report'

--- a/azure/pipelines/code-coverage.yml
+++ b/azure/pipelines/code-coverage.yml
@@ -44,14 +44,26 @@ jobs:
       useGlobalJson: true
       performMultiLevelLookup: true
   # Restore
-  - script: dotnet tool restore --configfile $(NuGet_Configuration_File)
+  - task: DotNetCoreCLI@2
     displayName: 'Install .NET Tools'
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'restore --configfile $(NuGet_Configuration_File)'
   # Collect
-  - script: dotnet test $(Solution_File) --collect:"XPlat Code Coverage" --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)
+  - task: DotNetCoreCLI@2
     displayName: 'Collect Code Coverage'
+    inputs:
+      command: 'test'
+      arguments: '$(Solution_File) --collect:"XPlat Code Coverage" --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
+      publishTestResults: false
   # Generate
-  - script: dotnet tool run reportgenerator "-reports:$(Coverage_Reports_Glob)" "-targetdir:$(Report_Target_Directory)" -reporttypes:$(Report_Types)
+  - task: DotNetCoreCLI@2
     displayName: 'Generate Report'
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'run reportgenerator "-reports:$(Coverage_Reports_Glob)" "-targetdir:$(Report_Target_Directory)" -reporttypes:$(Report_Types)'
   # Report
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish Results'

--- a/scripts/Test-Coverage.ps1
+++ b/scripts/Test-Coverage.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 6.0
+
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [switch]$OpenReport
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$RepositoryRootPath = (Get-Item -Path $PSScriptRoot).Parent
+$TestResultsDirectory = Join-Path -Path $RepositoryRootPath -ChildPath 'source' -AdditionalChildPath 'TestResults'
+$SolutionFile = Join-Path -Path $RepositoryRootPath -ChildPath 'source' -AdditionalChildPath 'F0.Analyzers.sln'
+$RunsettingsFile = Join-Path -Path $RepositoryRootPath -ChildPath 'source' -AdditionalChildPath 'test', 'coverlet.runsettings'
+$NuGetConfigurationFile = Join-Path -Path $RepositoryRootPath -ChildPath 'source' -AdditionalChildPath 'nuget.config'
+$CoverageReportsGlob = Join-Path -Path $TestResultsDirectory -ChildPath '**' -AdditionalChildPath 'coverage.cobertura.xml'
+$ReportTargetDirectory = Join-Path -Path $TestResultsDirectory -ChildPath 'coveragereport'
+$ReportTypes = 'HtmlInline_AzurePipelines_Dark'
+$ReportTargetFile = Join-Path -Path $ReportTargetDirectory -ChildPath 'index.html'
+
+if (Test-Path -Path $TestResultsDirectory) {
+    Remove-Item -Path $TestResultsDirectory -Recurse
+}
+
+dotnet clean $SolutionFile
+dotnet test $SolutionFile --collect:"XPlat Code Coverage" --results-directory $TestResultsDirectory --settings $RunsettingsFile
+
+dotnet tool restore --configfile $NuGetConfigurationFile
+dotnet tool run reportgenerator "-reports:$CoverageReportsGlob" "-targetdir:$ReportTargetDirectory" -reporttypes:$ReportTypes
+
+if ($OpenReport) {
+    Invoke-Item $ReportTargetFile
+}

--- a/scripts/Test-Unit.ps1
+++ b/scripts/Test-Unit.ps1
@@ -1,0 +1,17 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [switch]$ReleaseConfiguration
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$BuildConfiguration = $ReleaseConfiguration ? 'Release' : 'Debug'
+
+$RepositoryRootPath = (Get-Item -Path $PSScriptRoot).Parent
+$SolutionFilterFile = Join-Path -Path $RepositoryRootPath -ChildPath 'source' -AdditionalChildPath 'F0.Analyzers.Core.slnf'
+
+dotnet test $SolutionFilterFile --configuration $BuildConfiguration

--- a/source/test/coverlet.runsettings
+++ b/source/test/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[F0.CodeAnalysis.Testing]*</Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
follow-ups:
* change agent from _windows_ to _ubuntu_ (faster) - #45
* exclude _nullable attributes_ from Code Coverage Tab - #46
* add markdown status badge with link to latest code coverage report - #47
* fail pipeline when code coverage not 100 % - #48

to view the _Code Coverage Report_
* click "Show all checks" in this PR
* go to "Details" of "code_coverage windows"
* "View more details on Azure Pipelines"
* tap the back-button `<-`
* switch to the "Code Coverage" tab