### PR TITLE
ci: merge azure pipelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ tab_width = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{config,json,yml}]
+[*.{config,json,yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:

--- a/azure/pipelines/azure-pipelines.yml
+++ b/azure/pipelines/azure-pipelines.yml
@@ -1,0 +1,30 @@
+name: 'Azure Pipelines'
+
+trigger:
+  branches:
+    include:
+    - master
+pr:
+  branches:
+    include:
+    - master
+
+variables:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  Image_Name: 'ubuntu-18.04'
+  Build_Configuration: 'Release'
+
+jobs:
+# Unit Tests
+- template: templates/unit-tests.yml
+  parameters:
+    imageName: ${{ variables.Image_Name }}
+# Code Coverage
+- template: templates/code-coverage.yml
+  parameters:
+    imageName: ${{ variables.Image_Name }}
+# Mutation Testing
+- template: templates/mutation-testing.yml
+  parameters:
+    imageName: ${{ variables.Image_Name }}

--- a/azure/pipelines/azure-pipelines.yml
+++ b/azure/pipelines/azure-pipelines.yml
@@ -1,16 +1,19 @@
 name: 'Azure Pipelines'
 
 trigger:
+  batch: false
   branches:
     include:
     - master
 pr:
+  autoCancel: false
   branches:
     include:
     - master
 
 variables:
   DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   Image_Name: 'ubuntu-18.04'
   Build_Configuration: 'Release'

--- a/azure/pipelines/templates/code-coverage.yml
+++ b/azure/pipelines/templates/code-coverage.yml
@@ -1,31 +1,19 @@
-name: 'Code Coverage'
-
-trigger:
-  branches:
-    include:
-    - master
-pr:
-  branches:
-    include:
-    - master
-
-variables:
-  DOTNET_NOLOGO: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
+parameters:
+- name: imageName
+  displayName: 'Agent'
+  type: string
+  default: 'windows-latest'
 
 jobs:
 - job: 'code_coverage'
-  strategy:
-    matrix:
-      ubuntu:
-        imageName: 'ubuntu-18.04'
+  displayName: 'Code Coverage'
   pool:
-    vmImage: $(imageName)
+    vmImage: ${{ parameters.imageName }}
 
   variables:
-    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.sln'
-    Solution_Filter_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.Core.slnf'
+    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.Core.slnf'
     NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/nuget.config'
+    Tool_Manifest_File: '$(System.DefaultWorkingDirectory)/.config/dotnet-tools.json'
     Test_Results_Directory: '$(System.DefaultWorkingDirectory)/source/TestResults'
     Runsettings_File: '$(System.DefaultWorkingDirectory)/source/test/coverlet.runsettings'
     Coverage_Reports_Glob: '$(System.DefaultWorkingDirectory)/source/TestResults/**/coverage.cobertura.xml'
@@ -46,6 +34,12 @@ jobs:
       performMultiLevelLookup: true
   # Restore
   - task: DotNetCoreCLI@2
+    displayName: 'Install .NET Tools'
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'restore --configfile $(NuGet_Configuration_File) --tool-manifest $(Tool_Manifest_File) --no-cache'
+  - task: DotNetCoreCLI@2
     displayName: 'Restore Dependencies'
     inputs:
       command: 'restore'
@@ -53,18 +47,18 @@ jobs:
       feedsToUse: 'config'
       nugetConfigPath: '$(NuGet_Configuration_File)'
       verbosityRestore: 'Minimal'
+  # Build
   - task: DotNetCoreCLI@2
-    displayName: 'Install .NET Tools'
+    displayName: 'Build Projects'
     inputs:
-      command: 'custom'
-      custom: 'tool'
-      arguments: 'restore --configfile $(NuGet_Configuration_File)'
+      command: 'build'
+      arguments: '$(Solution_File) --no-restore --nologo'
   # Collect
   - task: DotNetCoreCLI@2
     displayName: 'Collect Code Coverage'
     inputs:
       command: 'test'
-      arguments: '$(Solution_Filter_File) --collect:"XPlat Code Coverage" --nologo --no-restore --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
+      arguments: '$(Solution_File) --collect:"XPlat Code Coverage" --no-build --nologo --results-directory $(Test_Results_Directory) --settings $(Runsettings_File)'
       publishTestResults: false
   # Generate
   - task: DotNetCoreCLI@2
@@ -72,7 +66,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'tool'
-      arguments: 'run reportgenerator "-reports:$(Coverage_Reports_Glob)" "-targetdir:$(Report_Target_Directory)" -reporttypes:$(Report_Types)'
+      arguments: 'run reportgenerator -reports:$(Coverage_Reports_Glob) -targetdir:$(Report_Target_Directory) -reporttypes:$(Report_Types)'
   # Report
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish Results'

--- a/azure/pipelines/templates/mutation-testing.yml
+++ b/azure/pipelines/templates/mutation-testing.yml
@@ -1,31 +1,19 @@
-name: 'Mutation Testing'
-
-trigger:
-  branches:
-    include:
-    - master
-pr:
-  branches:
-    include:
-    - master
-
-variables:
-  DOTNET_NOLOGO: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
+parameters:
+- name: imageName
+  displayName: 'Agent'
+  type: string
+  default: 'windows-latest'
 
 jobs:
 - job: 'mutation_testing'
-  strategy:
-    matrix:
-      ubuntu:
-        imageName: 'ubuntu-18.04'
+  displayName: 'Mutation Testing'
   pool:
-    vmImage: $(imageName)
+    vmImage: ${{ parameters.imageName }}
 
   variables:
-    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.sln'
-    Test_Project_Directory: '$(System.DefaultWorkingDirectory)/source/test/F0.Analyzers.Tests'
     NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/nuget.config'
+    Tool_Manifest_File: '$(System.DefaultWorkingDirectory)/.config/dotnet-tools.json'
+    Test_Project_Directory: '$(System.DefaultWorkingDirectory)/source/test/F0.Analyzers.Tests'
     Stryker_Configuration_File: '$(System.DefaultWorkingDirectory)/source/test/stryker-config.json'
 
   steps:
@@ -41,19 +29,11 @@ jobs:
       performMultiLevelLookup: true
   # Restore
   - task: DotNetCoreCLI@2
-    displayName: 'Restore Dependencies'
-    inputs:
-      command: 'restore'
-      restoreArguments: '$(Solution_File)'
-      feedsToUse: 'config'
-      nugetConfigPath: '$(NuGet_Configuration_File)'
-      verbosityRestore: 'Minimal'
-  - task: DotNetCoreCLI@2
     displayName: 'Install .NET Tools'
     inputs:
       command: 'custom'
       custom: 'tool'
-      arguments: 'restore --configfile $(NuGet_Configuration_File)'
+      arguments: 'restore --configfile $(NuGet_Configuration_File) --tool-manifest $(Tool_Manifest_File) --no-cache'
   # Mutate
   - task: DotNetCoreCLI@2
     displayName: 'Mutate Project'

--- a/azure/pipelines/templates/unit-tests.yml
+++ b/azure/pipelines/templates/unit-tests.yml
@@ -1,30 +1,17 @@
-name: 'Unit Tests'
-
-trigger:
-  branches:
-    include:
-    - master
-pr:
-  branches:
-    include:
-    - master
-
-variables:
-  DOTNET_NOLOGO: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
+parameters:
+- name: imageName
+  displayName: 'Agent'
+  type: string
+  default: 'windows-latest'
 
 jobs:
 - job: 'unit_tests'
-  strategy:
-    matrix:
-      ubuntu:
-        imageName: 'ubuntu-18.04'
+  displayName: 'Unit Tests'
   pool:
-    vmImage: $(imageName)
+    vmImage: ${{ parameters.imageName }}
 
   variables:
-    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.sln'
-    Solution_Filter_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.Core.slnf'
+    Solution_File: '$(System.DefaultWorkingDirectory)/source/F0.Analyzers.Core.slnf'
     NuGet_Configuration_File: '$(System.DefaultWorkingDirectory)/nuget.config'
 
   steps:
@@ -47,12 +34,18 @@ jobs:
       feedsToUse: 'config'
       nugetConfigPath: '$(NuGet_Configuration_File)'
       verbosityRestore: 'Minimal'
+  # Build
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Projects'
+    inputs:
+      command: 'build'
+      arguments: '$(Solution_File) --no-restore --nologo'
   # Test
   - task: DotNetCoreCLI@2
     displayName: 'Execute Unit Tests'
     inputs:
       command: 'test'
-      arguments: '$(Solution_Filter_File) --logger trx --nologo --no-restore'
+      arguments: '$(Solution_File) --logger trx --no-build --nologo'
       publishTestResults: false
   # Publish
   - task: PublishTestResults@2


### PR DESCRIPTION
_GitHub_ creates 1 **Check** per _Azure Pipeline_ and per _Job_.

Our 3 pipelines (test report, code coverage, mutation testing) with a single job each result in 6 _Checks_.
Also, all 3 resulting artifacts are each in their individual result page on _Azure Pipelines_.
So we have to navigate to 3 pages in order to inspect the _Test Report_, the _Code Coverage_ and the _Mutation Report_.

This PR merges those 3 pipelines into a single pipeline, where the 3 respective jobs are still in their separate `yml` file and are consumed by the pipeline as _templates_.
This results in having only 4 _Checks_ (instead of 6), and all 3 artifacts are accessible from a single page on _Azure DevOps_.

![GitHub Checks](https://user-images.githubusercontent.com/38893694/103179589-eedd4800-488d-11eb-9858-f4bcb5fa674b.png)

![Azure Pipelines](https://user-images.githubusercontent.com/38893694/103179421-3cf14c00-488c-11eb-80c9-f11493bf54c6.png)

Additionally, this PR sets the `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` environment variable to `true` on all CI runs, which prevents the initial population of the local package cache.
