### PR TITLE
git(attributes): explicitly normalize end-of-line and use built-in patterns

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,30 @@
 * text=auto
 
+*.config text
+*.cs text diff=csharp
+*.cshtml text
+*.csproj text
+*.css text diff=css
+*.editorconfig text
+*.htm text diff=html
+*.html text diff=html
+*.json text
+*.md text diff=markdown
+*.props text
+*.ps1 text
+*.razor text
+*.resx text
+*.runsettings text
+*.sln text
+*.slnf text
+*.targets text
+*.txt text
+*.vb text
+*.vbproj text
+*.vsixmanifest text
+*.xaml text
+*.xml text
+*.yaml text
+*.yml text
+
 *.png binary


### PR DESCRIPTION
explicit end-of-line conversions
use built-in diff patterns

Checks are failing: see #58, which fixes _restore_ and _test_ (feed "https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" no longer exists; _Microsoft.CodeAnalysis.Testing_ packages were moved)