### PR TITLE
fix(object-initializer): prevent code action for collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 CHANGELOG
 
 ## vNext
+### Analyzers
+- Fixed `ObjectInitializer` code refactoring, no longer registering code actions with collection types.
+
 ### Visual Studio Extension
 - Removed _install_ and _uninstall_ scripts (NuGet tools).
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0.100",
+    "rollForward": "feature"
   }
 }

--- a/source/example/F0.Analyzers.Example/CodeAnalysis/CodeRefactorings/ObjectInitializerExample.cs
+++ b/source/example/F0.Analyzers.Example/CodeAnalysis/CodeRefactorings/ObjectInitializerExample.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using F0.Analyzers.Example.Dependencies.Dependency;
 using F0.Analyzers.Example.Shared;
 using Microsoft.Extensions.Hosting;
@@ -63,6 +64,11 @@ namespace F0.Analyzers.Example.CodeAnalysis.CodeRefactorings
 				Property = 2
 			};
 		}
+
+		public IEnumerable<string> GetCollection()
+		{
+			return new List<string>();
+		} 
 
 		public BaseClass GetInheritingType()
 		{

--- a/source/test/F0.Analyzers.Tests/CodeAnalysis/CodeRefactorings/ObjectInitializerTests.Collections.cs
+++ b/source/test/F0.Analyzers.Tests/CodeAnalysis/CodeRefactorings/ObjectInitializerTests.Collections.cs
@@ -1,0 +1,79 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace F0.Tests.CodeAnalysis.CodeRefactorings
+{
+	public partial class ObjectInitializerTests
+	{
+		[Fact]
+		public async Task ComputeRefactoringsAsync_Array_NoOp()
+		{
+			var code =
+				@"using System;
+
+				class C
+				{
+					void Test()
+					{
+						var array = [|new int[42]|];
+					}
+				}";
+
+			await VerifyNoOpAsync(code);
+		}
+
+		[Fact]
+		public async Task ComputeRefactoringsAsync_ArrayList_NoOp()
+		{
+			var code =
+				@"using System;
+				using System.Collections;
+
+				class C
+				{
+					void Test()
+					{
+						var list = [|new ArrayList()|];
+					}
+				}";
+
+			await VerifyNoOpAsync(code);
+		}
+
+		[Fact]
+		public async Task ComputeRefactoringsAsync_Collection_NoOp()
+		{
+			var code =
+				@"using System;
+				using System.Collections.Generic;
+
+				class C
+				{
+					void Test()
+					{
+						var collection = [|new List<int>()|];
+					}
+				}";
+
+			await VerifyNoOpAsync(code);
+		}
+
+		[Fact]
+		public async Task ComputeRefactoringsAsync_AssociativeCollection_NoOp()
+		{
+			var code =
+				@"using System;
+				using System.Collections.Generic;
+
+				class C
+				{
+					void Test()
+					{
+						var map = [|new Dictionary<int, string>()|];
+					}
+				}";
+
+			await VerifyNoOpAsync(code);
+		}
+	}
+}


### PR DESCRIPTION
fixes #53

also specify a roll-forward policy as fallback, if exact SDK version is missing