### PR TITLE
feat: add suppressor of CA1707 for test methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 CHANGELOG
 
 ## vNext
+### Analyzers
+- Added `IdentifiersShouldNotContainUnderscores` diagnostic suppressor, suppressing _Warning CA1707_ for _MSTest_, _NUnit_ and _xUnit.net_ test methods.
 
 ## v0.9.0 (2022-02-04)
 ### Analyzers

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ supports [17.0.0](https://docs.microsoft.com/en-us/visualstudio/releases/2022/re
 ### Rider
 supports [2021.3](https://www.jetbrains.com/rider/whatsnew/2021-3/) and later
 ### Visual Studio Code
-supports _OmniSharp (C#)_ [1.24.0](https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.24.0) and later
+supports _OmniSharp (C#)_ [1.24.1](https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.24.1) and later

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ requires _Roslyn v4.0.1_ or later (see [packages of the .NET Compiler Platform](
 ### .NET 6.0
 supports [SDK 6.0.100](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.0/6.0.0.md) and later
 ### Visual Studio 2022
-supports [17.0.0](https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-notes#17.0.0) and later
+supports [17.0.0](https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-notes-v17.0) and later
 ### Rider
 supports [2021.3](https://www.jetbrains.com/rider/whatsnew/2021-3/) and later
 ### Visual Studio Code

--- a/documentation/F0.Analyzers.md
+++ b/documentation/F0.Analyzers.md
@@ -3,6 +3,7 @@
 * [Diagnostic Analyzers](#diagnostic-analyzers)
 * [Code Fixes](#code-fixes)
 * [Code Refactorings](#code-refactorings)
+* [Diagnostic Suppressors](#diagnostic-suppressors)
 
 ## Diagnostic Analyzers
 
@@ -27,3 +28,9 @@ Namespace: [F0.CodeAnalysis.CodeFixes](../source/production/F0.Analyzers/CodeAna
 Namespace: [F0.CodeAnalysis.CodeRefactorings](../source/production/F0.Analyzers/CodeAnalysis/CodeRefactorings/)
 
 * [ObjectInitializer](./refactorings/ObjectInitializer.md)
+
+## Diagnostic Suppressors
+
+Namespace: [F0.CodeAnalysis.Suppressors](../source/production/F0.Analyzers/CodeAnalysis/Suppressors/)
+
+* CA1707 [IdentifiersShouldNotContainUnderscoresSuppressor](./suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.md)

--- a/documentation/suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.md
+++ b/documentation/suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.md
@@ -1,0 +1,101 @@
+# Suppress CA1707 for test methods
+
+DiagnosticSuppressor: [CA1707IdentifiersShouldNotContainUnderscoresSuppressor.cs](../../source/production/F0.Analyzers/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.cs)
+
+|            |                  |
+|------------|------------------|
+| ID         | F0CA1707         |
+| Suppresses | [CA1707][ca1707] |
+| Applies to | `[vNext,)`       |
+
+## Summary
+
+Suppress warning [CA1707][ca1707] on test methods to allow the best practices naming standard for tests.
+
+## Remarks
+
+[CA1707][ca1707] reports a warning on non-field identifiers when containing underscores, i.e., a `_` character.
+
+The [best practices for writing unit tests in .NET](https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices) suggest the following [naming standard](https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices#naming-your-tests):
+
+> The name of your test should consist of three parts:
+>
+> - The name of the method being tested.
+> - The scenario under which it's being tested.
+> - The expected behavior when the scenario is invoked.
+
+These parts should be separated by the _underscore_ (`_`) character.
+
+[CA1707][ca1707] is suppressed only for _MSTest_, _NUnit_ and _xUnit.net_ test methods.
+For regular methods and other identifiers, [CA1707][ca1707] is not suppressed.
+
+### MSTest
+A method is a _MSTest_ test method, when it has
+- either the `TestMethodAttribute`
+- or the `DataTestMethodAttribute`
+
+and the containing _class_ is attributed with
+- `TestClassAttribute`
+
+from the _namespace_ `Microsoft.VisualStudio.TestTools.UnitTesting`.
+
+### NUnit
+A method is an _NUnit_ test method, when it has one of the following _attributes_ (Namespace: `NUnit.Framework`):
+- `TestAttribute`
+- `TestCaseAttribute`
+- `TestCaseSourceAttribute`
+- `CombinatorialAttribute`
+- `PairwiseAttribute`
+- `SequentialAttribute`
+- `TheoryAttribute`
+
+### xUnit.net
+A method is a _xUnit.net_ test method, when it has one of the following _attributes_ (Namespace: `Xunit`):
+- `FactAttribute`
+- `TheoryAttribute`
+
+## Example
+
+```cs
+using Xunit;
+
+namespace My_Namespace; // Remove the underscores from namespace name 'My_Namespace'
+
+public class My_Tests // Remove the underscores from type name My_Namespace.My_Tests
+{
+    [Fact]
+    public void Given_When_Then() // Warning CA1707 suppressed
+    {
+        Assert.Equal(240, 0x_F0);
+    }
+
+    [Theory]
+    [InlineData(0x_F0)]
+    public void MethodUnderTest_Scenario_ExpectedResult(int value) // Warning CA1707 suppressed
+    {
+        Assert.Equal(240, value);
+    }
+
+    public int My_Property { get; set; } // Remove the underscores from member name My_Namespace.My_Tests.My_Property
+
+    public void My_Method() // Remove the underscores from member name My_Namespace.My_Tests.My_Method()
+        => throw null;
+
+    public void MyMethod<Method_TypeParameter>() // On method My_Namespace.My_Tests.MyMethod<Method_TypeParameter>(), remove the underscores from generic type parameter name Method_TypeParameter
+        => throw null;
+}
+```
+
+## See also
+
+- [Warning CA1707][ca1707]
+- [MSTest](https://github.com/microsoft/testfx)
+- [NUnit](https://github.com/nunit/nunit)
+- [xUnit.net](https://github.com/xunit/xunit)
+
+## History
+
+- [vNext](../../CHANGELOG.md#vNext)
+
+
+  [ca1707]: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1707

--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,6 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -7,6 +7,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>6.0</AnalysisLevel>
+    <AnalysisMode>All</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <NoWarn />
     <WarningsAsErrors />
     <WarningsNotAsErrors />
@@ -14,10 +21,20 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.CLSCompliantAttribute">
+      <_Parameter1>false</_Parameter1>
+      <_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
+      <_Parameter1_IsLiteral>false</_Parameter1_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>

--- a/source/F0.Analyzers.Core.slnf
+++ b/source/F0.Analyzers.Core.slnf
@@ -8,6 +8,7 @@
       "example\\F0.Analyzers.Example.CSharp8\\F0.Analyzers.Example.CSharp8.csproj",
       "example\\F0.Analyzers.Example.CSharp9\\F0.Analyzers.Example.CSharp9.csproj",
       "example\\F0.Analyzers.Example.Dependencies\\F0.Analyzers.Example.Dependencies.csproj",
+      "example\\F0.Analyzers.Example.Tests\\F0.Analyzers.Example.Tests.csproj",
       "example\\F0.Analyzers.Example\\F0.Analyzers.Example.csproj",
       "package\\F0.Analyzers.Package\\F0.Analyzers.Package.csproj",
       "performance\\F0.Analyzers.Benchmarks\\F0.Analyzers.Benchmarks.csproj",

--- a/source/F0.Analyzers.Example.slnf
+++ b/source/F0.Analyzers.Example.slnf
@@ -8,6 +8,7 @@
       "example\\F0.Analyzers.Example.CSharp8\\F0.Analyzers.Example.CSharp8.csproj",
       "example\\F0.Analyzers.Example.CSharp9\\F0.Analyzers.Example.CSharp9.csproj",
       "example\\F0.Analyzers.Example.Dependencies\\F0.Analyzers.Example.Dependencies.csproj",
+      "example\\F0.Analyzers.Example.Tests\\F0.Analyzers.Example.Tests.csproj",
       "example\\F0.Analyzers.Example\\F0.Analyzers.Example.csproj"
     ]
   }

--- a/source/F0.Analyzers.sln
+++ b/source/F0.Analyzers.sln
@@ -41,7 +41,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "F0.Analyzers.Example.CSharp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "F0.Analyzers.Example.CSharp9", "example\F0.Analyzers.Example.CSharp9\F0.Analyzers.Example.CSharp9.csproj", "{BF6085B7-EF86-49A1-9FED-9308982A7A89}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "F0.Analyzers.Example.CSharp10", "example\F0.Analyzers.Example.CSharp10\F0.Analyzers.Example.CSharp10.csproj", "{4FF74BB6-FD3D-443A-99F7-A5113EBE56C4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "F0.Analyzers.Example.CSharp10", "example\F0.Analyzers.Example.CSharp10\F0.Analyzers.Example.CSharp10.csproj", "{4FF74BB6-FD3D-443A-99F7-A5113EBE56C4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "F0.Analyzers.Example.Tests", "example\F0.Analyzers.Example.Tests\F0.Analyzers.Example.Tests.csproj", "{A8481C5B-7F58-4198-80AF-ECBE18BB9EC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -105,6 +107,10 @@ Global
 		{4FF74BB6-FD3D-443A-99F7-A5113EBE56C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4FF74BB6-FD3D-443A-99F7-A5113EBE56C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4FF74BB6-FD3D-443A-99F7-A5113EBE56C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8481C5B-7F58-4198-80AF-ECBE18BB9EC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8481C5B-7F58-4198-80AF-ECBE18BB9EC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8481C5B-7F58-4198-80AF-ECBE18BB9EC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8481C5B-7F58-4198-80AF-ECBE18BB9EC7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -124,6 +130,7 @@ Global
 		{0C22B8EE-947D-4962-BBB3-DC1381E96436} = {EF42DC6B-A41F-4459-83E0-296E02BD86B9}
 		{BF6085B7-EF86-49A1-9FED-9308982A7A89} = {EF42DC6B-A41F-4459-83E0-296E02BD86B9}
 		{4FF74BB6-FD3D-443A-99F7-A5113EBE56C4} = {EF42DC6B-A41F-4459-83E0-296E02BD86B9}
+		{A8481C5B-7F58-4198-80AF-ECBE18BB9EC7} = {EF42DC6B-A41F-4459-83E0-296E02BD86B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4C250660-2192-45B9-A87B-5E23C0AAA835}

--- a/source/example/Directory.Build.props
+++ b/source/example/Directory.Build.props
@@ -11,4 +11,8 @@
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AnalysisMode>Default</AnalysisMode>
+  </PropertyGroup>
+
 </Project>

--- a/source/example/F0.Analyzers.Example.CSharp10/Properties/AssemblyInfo.cs
+++ b/source/example/F0.Analyzers.Example.CSharp10/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyDescription("F0.Analyzers code sample.")]
+[assembly: AssemblyCopyright("Copyright © f[0] 2022")]

--- a/source/example/F0.Analyzers.Example.Tests/.globalconfig
+++ b/source/example/F0.Analyzers.Example.Tests/.globalconfig
@@ -1,0 +1,4 @@
+is_global = true
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none

--- a/source/example/F0.Analyzers.Example.Tests/CodeAnalysis/Suppressors/MSTest.cs
+++ b/source/example/F0.Analyzers.Example.Tests/CodeAnalysis/Suppressors/MSTest.cs
@@ -1,0 +1,35 @@
+using F0.Analyzers.Example.Tests.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace F0.Analyzers.Example.Tests.CodeAnalysis.Suppressors
+{
+	[TestClass]
+	public class MSTest
+	{
+		private readonly PrimeService primeService;
+
+		public MSTest()
+		{
+			primeService = new PrimeService();
+		}
+
+		[TestMethod]
+		public void IsPrime_InputIs1_ReturnFalse()
+		{
+			var result = primeService.IsPrime(1);
+
+			Assert.IsFalse(result, "1 should not be prime");
+		}
+
+		[DataTestMethod]
+		[DataRow(-1)]
+		[DataRow(0)]
+		[DataRow(1)]
+		public void IsPrime_ValuesLessThan2_ReturnFalse(int value)
+		{
+			var result = primeService.IsPrime(value);
+
+			Assert.IsFalse(result, $"{value} should not be prime");
+		}
+	}
+}

--- a/source/example/F0.Analyzers.Example.Tests/CodeAnalysis/Suppressors/NUnit.cs
+++ b/source/example/F0.Analyzers.Example.Tests/CodeAnalysis/Suppressors/NUnit.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics.CodeAnalysis;
+using F0.Analyzers.Example.Tests.Services;
+using NUnit.Framework;
+
+namespace F0.Analyzers.Example.Tests.CodeAnalysis.Suppressors
+{
+	[TestFixture]
+	[SuppressMessage("Style", "IDE0022:Use expression body for methods", Justification = "Example")]
+	public class NUnit
+	{
+		private PrimeService primeService;
+
+		[SetUp]
+		public void SetUp()
+		{
+			primeService = new PrimeService();
+		}
+
+		[Test]
+		public void IsPrime_InputIs1_ReturnFalse()
+		{
+			var result = primeService.IsPrime(1);
+
+			Assert.IsFalse(result, "1 should not be prime");
+		}
+
+		[TestCase(-1)]
+		[TestCase(0)]
+		[TestCase(1)]
+		public void IsPrime_ValuesLessThan2_ReturnFalse(int value)
+		{
+			var result = primeService.IsPrime(value);
+
+			Assert.IsFalse(result, $"{value} should not be prime");
+		}
+
+		[TestCaseSource(nameof(TestCaseSource))]
+		public void TestCaseSource_Attribute(int value)
+		{
+			var result = primeService.IsPrime(value);
+
+			Assert.IsFalse(result, $"{value} should not be prime");
+		}
+
+		private static int[] TestCaseSource => new int[] { -2, -3 };
+
+		[Combinatorial]
+		public void Combinatorial_Attribute([Values(1, 2)] int number, [Values("A", "B")] string text)
+		{
+			var actual = number + text;
+
+			Assert.That(actual, Is.AnyOf("1A", "1B", "2A", "2B"));
+		}
+
+		[Pairwise]
+		public void Pairwise_Attribute([Values("a", "b", "c")] string left, [Values("+", "-")] string middle, [Values("x", "y")] string right)
+		{
+			var actual = left + middle + right;
+
+			Assert.That(actual, Is.AnyOf("a-x", "a+y", "b+x", "b-y", "c-x", "c+y"));
+		}
+
+		[Sequential]
+		public void Sequential_Attribute([Values(1, 2, 3)] int number, [Values("A", "B")] string text)
+		{
+			var actual = number + text;
+
+			Assert.That(actual, Is.AnyOf("1A", "2B", "3"));
+		}
+
+		[Theory]
+		public void Theory_Attribute(int number)
+		{
+			Assume.That(number != 0);
+
+			var @delegate = () => 0 / number;
+
+			Assert.That(@delegate, Throws.Nothing);
+		}
+
+		[DatapointSource]
+		public int[] DatapointSource => new int[] { -1, 0, 1 };
+	}
+}

--- a/source/example/F0.Analyzers.Example.Tests/CodeAnalysis/Suppressors/xUnit.cs
+++ b/source/example/F0.Analyzers.Example.Tests/CodeAnalysis/Suppressors/xUnit.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using F0.Analyzers.Example.Tests.Services;
+using Xunit;
+
+namespace F0.Analyzers.Example.Tests.CodeAnalysis.Suppressors
+{
+	[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "xunit")]
+	public class xUnit
+	{
+		private readonly PrimeService primeService;
+
+		public xUnit()
+		{
+			primeService = new PrimeService();
+		}
+
+		[Fact]
+		public void IsPrime_InputIs1_ReturnFalse()
+		{
+			var result = primeService.IsPrime(1);
+
+			Assert.False(result, "1 should not be prime");
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(0)]
+		[InlineData(1)]
+		public void IsPrime_ValuesLessThan2_ReturnFalse(int value)
+		{
+			var result = primeService.IsPrime(value);
+
+			Assert.False(result, $"{value} should not be prime");
+		}
+	}
+}

--- a/source/example/F0.Analyzers.Example.Tests/F0.Analyzers.Example.Tests.csproj
+++ b/source/example/F0.Analyzers.Example.Tests/F0.Analyzers.Example.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/source/example/F0.Analyzers.Example.Tests/Properties/AssemblyInfo.cs
+++ b/source/example/F0.Analyzers.Example.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Xunit;
+
+[assembly: AssemblyDescription("F0.Analyzers code sample.")]
+[assembly: AssemblyCopyright("Copyright © f[0] 2022")]
+
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+[assembly: Parallelizable(ParallelScope.Fixtures)]
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerClass)]

--- a/source/example/F0.Analyzers.Example.Tests/Services/PrimeService.cs
+++ b/source/example/F0.Analyzers.Example.Tests/Services/PrimeService.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace F0.Analyzers.Example.Tests.Services
+{
+	internal sealed class PrimeService
+	{
+		public bool IsPrime(int candidate)
+		{
+			if (candidate < 2)
+			{
+				return false;
+			}
+
+			throw new NotImplementedException("Please create a test first.");
+		}
+	}
+}

--- a/source/performance/.globalconfig
+++ b/source/performance/.globalconfig
@@ -1,0 +1,10 @@
+is_global = true
+
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = none
+
+# CA1309: Use ordinal string comparison
+dotnet_diagnostic.CA1309.severity = none
+
+# CA2000: Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = none

--- a/source/performance/F0.Analyzers.Benchmarks/CodeAnalysis/CodeFixes/DeclareRecordClassExplicitlyBenchmarks.cs
+++ b/source/performance/F0.Analyzers.Benchmarks/CodeAnalysis/CodeFixes/DeclareRecordClassExplicitlyBenchmarks.cs
@@ -27,7 +27,7 @@ record Record;
 	}
 
 	[Benchmark]
-	public Task UseConstantNullPattern()
+	public Task DeclareRecordClassExplicitly()
 		=> benchmark.InvokeAsync();
 
 	[GlobalCleanup]

--- a/source/performance/F0.Analyzers.Benchmarks/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressorBenchmarks.cs
+++ b/source/performance/F0.Analyzers.Benchmarks/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressorBenchmarks.cs
@@ -1,0 +1,91 @@
+using F0.Benchmarking.CodeAnalysis;
+using F0.Benchmarking.CodeAnalysis.Suppressors;
+using F0.CodeAnalysis.Suppressors;
+
+namespace F0.Benchmarks.CodeAnalysis.Suppressors;
+
+public class CA1707IdentifiersShouldNotContainUnderscoresSuppressorBenchmarks
+{
+	private readonly DiagnosticSuppressorBenchmark<CA1707IdentifiersShouldNotContainUnderscoresSuppressor> benchmark;
+
+	public CA1707IdentifiersShouldNotContainUnderscoresSuppressorBenchmarks()
+	{
+		benchmark = Measure.DiagnosticSuppressor<CA1707IdentifiersShouldNotContainUnderscoresSuppressor>();
+	}
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		var code =
+@"using Xunit;
+
+public class xUnit_Tests
+{
+	[Fact]
+	public void Given_When_Then()
+	{
+		Assert.Equal(240, 0x_F0);
+	}
+
+	[Theory]
+	[InlineData(0x_F0)]
+	public void MethodUnderTest_Scenario_ExpectedResult(int value)
+	{
+		Assert.Equal(240, value);
+	}
+}
+
+namespace Xunit
+{
+	using Xunit.Sdk;
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class FactAttribute : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class TheoryAttribute : FactAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public sealed class InlineDataAttribute : DataAttribute
+	{
+		public InlineDataAttribute(params object[] data) => throw null;
+	}
+}
+
+namespace Xunit.Sdk
+{
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	public abstract class DataAttribute : Attribute
+	{
+	}
+}";
+
+		var locations = benchmark.CreateLocations(
+			l => l.With(3, 14, 3, 25),
+			l => l.With(6, 17, 6, 32),
+			l => l.With(13, 17, 13, 56)
+		);
+
+		benchmark.Initialize(code, "xunit.core", LanguageVersion.Latest, locations);
+	}
+
+	[Benchmark]
+	public Task IdentifiersShouldNotContainUnderscoresSuppressor()
+		=> benchmark.InvokeAsync();
+
+	[GlobalCleanup]
+	public void Cleanup()
+	{
+		var diagnostics = benchmark.CreateDiagnostics(
+			d => d.WithLocation(3, 14, 3, 25).WithIsSuppressed(false),
+			d => d.WithLocation(6, 17, 6, 32).WithIsSuppressed(true),
+			d => d.WithLocation(13, 17, 13, 56).WithIsSuppressed(true)
+		);
+
+		benchmark.Inspect(diagnostics);
+	}
+}

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/AnalyzerBenchmark.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/AnalyzerBenchmark.cs
@@ -17,7 +17,7 @@ public abstract class AnalyzerBenchmark
 	{
 	}
 
-	protected TextSpan GetSpan(string code, LinePositionSpan span, bool isVerbatimStringLiteral)
+	protected static TextSpan GetSpan(string code, LinePositionSpan span, bool isVerbatimStringLiteral)
 	{
 		var zeroBasedSpan = new LinePositionSpan(new LinePosition(span.Start.Line - 1, span.Start.Character - 1), new LinePosition(span.End.Line - 1, span.End.Character - 1));
 
@@ -49,10 +49,10 @@ public abstract class AnalyzerBenchmark
 		return new TextSpan(start, length);
 	}
 
-	protected Document CreateDocument(string code, LanguageVersion languageVersion)
+	protected static Document CreateDocument(string code, LanguageVersion languageVersion)
 		=> CreateDocument(SourceText.From(code), languageVersion);
 
-	protected Document CreateDocument(SourceText code, LanguageVersion languageVersion)
+	protected static Document CreateDocument(SourceText code, LanguageVersion languageVersion)
 	{
 		var projectId = CreateProjectId();
 		var documentId = CreateDocumentId(projectId);
@@ -62,10 +62,10 @@ public abstract class AnalyzerBenchmark
 		return solution.GetDocument(documentId);
 	}
 
-	protected Project CreateProject(string code, LanguageVersion languageVersion)
+	protected static Project CreateProject(string code, LanguageVersion languageVersion)
 		=> CreateProject(SourceText.From(code), languageVersion);
 
-	protected Project CreateProject(SourceText code, LanguageVersion languageVersion)
+	protected static Project CreateProject(SourceText code, LanguageVersion languageVersion)
 	{
 		var projectId = CreateProjectId();
 		var documentId = CreateDocumentId(projectId);

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticAssert.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticAssert.cs
@@ -67,14 +67,14 @@ internal static class DiagnosticAssert
 		{
 			var message = $"- Unexpected {nameof(DiagnosticDescriptor)}:";
 			errors.AppendLine(message);
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Category)}: {expectedDiagnostic.Descriptor.Category} | {actualDiagnostic.Descriptor.Category}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.DefaultSeverity)}: {expectedDiagnostic.Descriptor.DefaultSeverity} | {actualDiagnostic.Descriptor.DefaultSeverity}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Description)}: {expectedDiagnostic.Descriptor.Description} | {actualDiagnostic.Descriptor.Description}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.HelpLinkUri)}: {expectedDiagnostic.Descriptor.HelpLinkUri} | {actualDiagnostic.Descriptor.HelpLinkUri}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Id)}: {expectedDiagnostic.Descriptor.Id} | {actualDiagnostic.Descriptor.Id}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.IsEnabledByDefault)}: {expectedDiagnostic.Descriptor.IsEnabledByDefault} | {actualDiagnostic.Descriptor.IsEnabledByDefault}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.MessageFormat)}: {expectedDiagnostic.Descriptor.MessageFormat} | {actualDiagnostic.Descriptor.MessageFormat}");
-			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Title)}: {expectedDiagnostic.Descriptor.Title} | {actualDiagnostic.Descriptor.Title}");
+			errors.AppendLine(nameof(DiagnosticDescriptor.Category), expectedDiagnostic.Descriptor.Category, actualDiagnostic.Descriptor.Category);
+			errors.AppendLine(nameof(DiagnosticDescriptor.DefaultSeverity), expectedDiagnostic.Descriptor.DefaultSeverity, actualDiagnostic.Descriptor.DefaultSeverity);
+			errors.AppendLine(nameof(DiagnosticDescriptor.Description), expectedDiagnostic.Descriptor.Description, actualDiagnostic.Descriptor.Description);
+			errors.AppendLine(nameof(DiagnosticDescriptor.HelpLinkUri), expectedDiagnostic.Descriptor.HelpLinkUri, actualDiagnostic.Descriptor.HelpLinkUri);
+			errors.AppendLine(nameof(DiagnosticDescriptor.Id), expectedDiagnostic.Descriptor.Id, actualDiagnostic.Descriptor.Id);
+			errors.AppendLine(nameof(DiagnosticDescriptor.IsEnabledByDefault), expectedDiagnostic.Descriptor.IsEnabledByDefault, actualDiagnostic.Descriptor.IsEnabledByDefault);
+			errors.AppendLine(nameof(DiagnosticDescriptor.MessageFormat), expectedDiagnostic.Descriptor.MessageFormat, actualDiagnostic.Descriptor.MessageFormat);
+			errors.AppendLine(nameof(DiagnosticDescriptor.Title), expectedDiagnostic.Descriptor.Title, actualDiagnostic.Descriptor.Title);
 		}
 
 		if (expectedDiagnostic.GetMessage() != actualDiagnostic.GetMessage())
@@ -107,4 +107,7 @@ internal static class DiagnosticAssert
 			errors.AppendLine(message);
 		}
 	}
+
+	private static void AppendLine<T>(this StringBuilder errors, string memberName, T expected, T actual)
+		=> _ = errors.AppendLine($"\t- {memberName}: {expected} | {actual}");
 }

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticAssert.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticAssert.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using System.Text;
+
+namespace F0.Benchmarking.CodeAnalysis;
+
+internal static class DiagnosticAssert
+{
+	internal static void AreEqual(Diagnostic expectedDiagnostic, Diagnostic actualDiagnostic)
+	{
+		var errors = new StringBuilder();
+
+		AreEqual(expectedDiagnostic, actualDiagnostic, errors);
+
+		if (errors.Length != 0)
+		{
+			errors.Replace(Environment.NewLine, String.Empty, errors.Length - Environment.NewLine.Length, Environment.NewLine.Length);
+			errors.Insert(0, $"Unexpected {nameof(Diagnostic)}:{Environment.NewLine}");
+			throw new InvalidOperationException(errors.ToString());
+		}
+	}
+
+	internal static void AreEqual(ImmutableArray<Diagnostic> expectedDiagnostics, ImmutableArray<Diagnostic> actualDiagnostics)
+	{
+		if (expectedDiagnostics.Length != actualDiagnostics.Length)
+		{
+			var expected = expectedDiagnostics.Length == 1 ? "diagnostic" : "diagnostics";
+			var actual = actualDiagnostics.Length == 1 ? "diagnostic" : "diagnostics";
+			var message = $"Expected {expectedDiagnostics.Length} {expected}, but actually found {actualDiagnostics.Length} {actual}.";
+			throw new InvalidOperationException(message);
+		}
+
+		var sortedDiagnostics = actualDiagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToImmutableArray();
+		var errors = new StringBuilder();
+
+		for (var i = 0; i < expectedDiagnostics.Length; i++)
+		{
+			var expectedDiagnostic = expectedDiagnostics[i];
+			var actualDiagnostic = sortedDiagnostics[i];
+
+			var length = errors.Length;
+
+			AreEqual(expectedDiagnostic, actualDiagnostic, errors);
+
+			if (errors.Length != length)
+			{
+				errors.Insert(length, $"{nameof(Diagnostic)} #{i + 1}{Environment.NewLine}");
+			}
+		}
+
+		if (errors.Length != 0)
+		{
+			errors.Replace(Environment.NewLine, String.Empty, errors.Length - Environment.NewLine.Length, Environment.NewLine.Length);
+			errors.Insert(0, $"Unexpected {nameof(Diagnostic)}(s):{Environment.NewLine}");
+			throw new InvalidOperationException(errors.ToString());
+		}
+	}
+
+	private static void AreEqual(Diagnostic expectedDiagnostic, Diagnostic actualDiagnostic, StringBuilder errors)
+	{
+		if (expectedDiagnostic.GetType() != actualDiagnostic.GetType() && !expectedDiagnostic.IsSuppressed && !actualDiagnostic.IsSuppressed)
+		{
+			var message = $"- {nameof(Type)}: Expected '{expectedDiagnostic.GetType()}', but actually is of '{actualDiagnostic.GetType()}'.";
+			errors.AppendLine(message);
+		}
+
+		if (!expectedDiagnostic.Descriptor.Equals(actualDiagnostic.Descriptor))
+		{
+			var message = $"- Unexpected {nameof(DiagnosticDescriptor)}:";
+			errors.AppendLine(message);
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Category)}: {expectedDiagnostic.Descriptor.Category} | {actualDiagnostic.Descriptor.Category}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.DefaultSeverity)}: {expectedDiagnostic.Descriptor.DefaultSeverity} | {actualDiagnostic.Descriptor.DefaultSeverity}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Description)}: {expectedDiagnostic.Descriptor.Description} | {actualDiagnostic.Descriptor.Description}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.HelpLinkUri)}: {expectedDiagnostic.Descriptor.HelpLinkUri} | {actualDiagnostic.Descriptor.HelpLinkUri}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Id)}: {expectedDiagnostic.Descriptor.Id} | {actualDiagnostic.Descriptor.Id}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.IsEnabledByDefault)}: {expectedDiagnostic.Descriptor.IsEnabledByDefault} | {actualDiagnostic.Descriptor.IsEnabledByDefault}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.MessageFormat)}: {expectedDiagnostic.Descriptor.MessageFormat} | {actualDiagnostic.Descriptor.MessageFormat}");
+			errors.AppendLine($"\t- {nameof(DiagnosticDescriptor.Title)}: {expectedDiagnostic.Descriptor.Title} | {actualDiagnostic.Descriptor.Title}");
+		}
+
+		if (expectedDiagnostic.GetMessage() != actualDiagnostic.GetMessage())
+		{
+			var message = $"- Message: Expected '{expectedDiagnostic.GetMessage()}', but actually is '{actualDiagnostic.GetMessage()}'.";
+			errors.AppendLine(message);
+		}
+
+		if (expectedDiagnostic.Location != actualDiagnostic.Location)
+		{
+			var message = $"- {nameof(Location)}: Expected '{expectedDiagnostic.Location}', but actually at '{actualDiagnostic.Location}'.";
+			errors.AppendLine(message);
+		}
+
+		if (expectedDiagnostic.Severity != actualDiagnostic.Severity)
+		{
+			var message = $"- {nameof(DiagnosticSeverity)}: Expected '{expectedDiagnostic.Severity}', but actually is '{actualDiagnostic.Severity}'.";
+			errors.AppendLine(message);
+		}
+
+		if (expectedDiagnostic.WarningLevel != actualDiagnostic.WarningLevel)
+		{
+			var message = $"- {nameof(Diagnostic.WarningLevel)}: Expected '{expectedDiagnostic.WarningLevel}', but actually has '{actualDiagnostic.WarningLevel}'.";
+			errors.AppendLine(message);
+		}
+
+		if (expectedDiagnostic.IsSuppressed != actualDiagnostic.IsSuppressed)
+		{
+			var message = $"- {nameof(Diagnostic.IsSuppressed)}: Expected '{expectedDiagnostic.IsSuppressed}', but actually is '{actualDiagnostic.IsSuppressed}'.";
+			errors.AppendLine(message);
+		}
+	}
+}

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticBuilder.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticBuilder.cs
@@ -2,12 +2,13 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace F0.Benchmarking.CodeAnalysis;
 
-public class DiagnosticBuilder
+public sealed class DiagnosticBuilder
 {
 	private readonly SourceText source;
 	private readonly SyntaxTree syntaxTree;
 	private TextSpan span;
 	private string[]? messageArguments;
+	private bool isSuppressed;
 
 	internal DiagnosticBuilder(SourceText source, SyntaxTree syntaxTree)
 	{
@@ -39,9 +40,25 @@ public class DiagnosticBuilder
 		return this;
 	}
 
+	public object WithIsSuppressed(bool isSuppressed)
+	{
+		this.isSuppressed = isSuppressed;
+
+		return this;
+	}
+
 	internal Diagnostic Build(DiagnosticDescriptor descriptor)
 	{
 		var location = BuildLocation();
+
+		if (isSuppressed)
+		{
+			var warningLevel = descriptor.DefaultSeverity == DiagnosticSeverity.Warning
+				? 1
+				: 0;
+			return Diagnostic.Create(descriptor.Id, descriptor.Category, descriptor.MessageFormat, descriptor.DefaultSeverity, descriptor.DefaultSeverity, descriptor.IsEnabledByDefault, warningLevel, isSuppressed, descriptor.Title, descriptor.Description, descriptor.HelpLinkUri, location, null, descriptor.CustomTags, null);
+		}
+
 		var diagnostic = messageArguments is null
 			? Diagnostic.Create(descriptor, location)
 			: Diagnostic.Create(descriptor, location, messageArguments);

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticBuilder.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/DiagnosticBuilder.cs
@@ -40,7 +40,7 @@ public sealed class DiagnosticBuilder
 		return this;
 	}
 
-	public object WithIsSuppressed(bool isSuppressed)
+	public DiagnosticBuilder WithIsSuppressed(bool isSuppressed)
 	{
 		this.isSuppressed = isSuppressed;
 

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/Diagnostics/DiagnosticReporter.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/Diagnostics/DiagnosticReporter.cs
@@ -1,9 +1,10 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace F0.Benchmarking.CodeAnalysis.Diagnostics;
 
-[System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1001:Missing diagnostic analyzer attribute.", Justification = "Benchmarking")]
+[SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1001:Missing diagnostic analyzer attribute.", Justification = "Benchmarking")]
 internal sealed class DiagnosticReporter : DiagnosticAnalyzer
 {
 	private ImmutableArray<DiagnosticDescriptor> supportedDiagnostics;

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/Diagnostics/DiagnosticReporter.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/Diagnostics/DiagnosticReporter.cs
@@ -1,0 +1,59 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace F0.Benchmarking.CodeAnalysis.Diagnostics;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1001:Missing diagnostic analyzer attribute.", Justification = "Benchmarking")]
+internal sealed class DiagnosticReporter : DiagnosticAnalyzer
+{
+	private ImmutableArray<DiagnosticDescriptor> supportedDiagnostics;
+	private ImmutableArray<LocationFactory> locationFactories;
+
+	public DiagnosticReporter()
+	{
+	}
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => supportedDiagnostics;
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+		context.EnableConcurrentExecution();
+
+		context.RegisterSyntaxTreeAction(SyntaxTreeAction);
+	}
+
+	private void SyntaxTreeAction(SyntaxTreeAnalysisContext context)
+	{
+		var descriptor = supportedDiagnostics.Single();
+
+		foreach (var locationFactory in locationFactories)
+		{
+			var location = locationFactory.Invoke(context.Tree);
+			var diagnostic = Diagnostic.Create(descriptor, location);
+			context.ReportDiagnostic(diagnostic);
+		}
+	}
+
+	public void SetSupportedDiagnostics(DiagnosticSuppressor suppressor, ImmutableArray<LocationFactory> locationFactories)
+	{
+		supportedDiagnostics = suppressor.SupportedSuppressions
+			.Select(static descriptor => descriptor.SuppressedDiagnosticId)
+			.Select(static id => CreateDiagnosticDescriptor(id))
+			.ToImmutableArray();
+
+		this.locationFactories = locationFactories;
+	}
+
+	private static DiagnosticDescriptor CreateDiagnosticDescriptor(string id)
+	{
+		return new DiagnosticDescriptor(id,
+			$"{nameof(DiagnosticDescriptor.Title)} of {id}",
+			$"{nameof(DiagnosticDescriptor.MessageFormat)} of {id}",
+			$"{nameof(DiagnosticDescriptor.Category)} of {id}",
+			DiagnosticSeverity.Warning,
+			true,
+			$"{nameof(DiagnosticDescriptor.Description)} of {id}",
+			$"{nameof(DiagnosticDescriptor.HelpLinkUri)} of {id}");
+	}
+}

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/LocationBuilder.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/LocationBuilder.cs
@@ -1,0 +1,34 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace F0.Benchmarking.CodeAnalysis;
+
+public sealed class LocationBuilder
+{
+	private readonly SourceText source;
+	private LinePosition start;
+	private LinePosition end;
+
+	internal LocationBuilder(SourceText source)
+	{
+		this.source = source;
+	}
+
+	public LocationBuilder With(int line, int column)
+		=> With(line, column, line, column);
+
+	public LocationBuilder With(int startLine, int startColumn, int endLine, int endColumn)
+	{
+		start = new LinePosition(startLine - 1, startColumn - 1);
+		end = new LinePosition(endLine - 1, endColumn - 1);
+
+		return this;
+	}
+
+	internal Location Build(SyntaxTree syntaxTree)
+	{
+		var lineSpan = new LinePositionSpan(start, end);
+		var textSpan = source.Lines.GetTextSpan(lineSpan);
+
+		return Location.Create(syntaxTree, textSpan);
+	}
+}

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/LocationFactory.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/LocationFactory.cs
@@ -1,0 +1,3 @@
+namespace F0.Benchmarking.CodeAnalysis;
+
+internal delegate Location LocationFactory(SyntaxTree syntaxTree);

--- a/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/Measure.cs
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/CodeAnalysis/Measure.cs
@@ -1,6 +1,7 @@
 using F0.Benchmarking.CodeAnalysis.CodeFixes;
 using F0.Benchmarking.CodeAnalysis.CodeRefactorings;
 using F0.Benchmarking.CodeAnalysis.Diagnostics;
+using F0.Benchmarking.CodeAnalysis.Suppressors;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -21,4 +22,8 @@ public static class Measure
 	public static CodeRefactoringBenchmark<TCodeRefactoring> CodeRefactoring<TCodeRefactoring>()
 		where TCodeRefactoring : CodeRefactoringProvider, new()
 		=> new CodeRefactoringBenchmark<TCodeRefactoring>();
+
+	public static DiagnosticSuppressorBenchmark<TDiagnosticSuppressor> DiagnosticSuppressor<TDiagnosticSuppressor>()
+		where TDiagnosticSuppressor : DiagnosticSuppressor, new()
+		=> new DiagnosticSuppressorBenchmark<TDiagnosticSuppressor>();
 }

--- a/source/performance/F0.CodeAnalysis.Benchmarking/F0.CodeAnalysis.Benchmarking.csproj
+++ b/source/performance/F0.CodeAnalysis.Benchmarking/F0.CodeAnalysis.Benchmarking.csproj
@@ -7,11 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ImplicitUsings)' == 'true' Or '$(ImplicitUsings)' == 'enable'">

--- a/source/production/.globalconfig
+++ b/source/production/.globalconfig
@@ -1,0 +1,13 @@
+is_global = true
+
+# CA1307: Specify StringComparison for clarity
+dotnet_diagnostic.CA1307.severity = none
+
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = none
+
+# RS1007: Provide localizable arguments to diagnostic descriptor constructor
+dotnet_diagnostic.RS1007.severity = none
+
+# RS1028: Provide non-null 'customTags' value to diagnostic descriptor constructor
+dotnet_diagnostic.RS1028.severity = none

--- a/source/production/F0.Analyzers/CodeAnalysis/CodeRefactorings/ObjectInitializer.cs
+++ b/source/production/F0.Analyzers/CodeAnalysis/CodeRefactorings/ObjectInitializer.cs
@@ -99,7 +99,6 @@ internal sealed class ObjectInitializer : CodeRefactoringProvider
 		return documentEditor.GetChangedDocument();
 	}
 
-	[SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1024:Symbols should be compared for equality", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/5715")]
 	private static IEnumerable<ISymbol> GetMutableMembers(in TypeInfo typeInfo, Compilation compilation)
 	{
 		var members = new HashSet<ISymbol>(SymbolNameComparer.Instance);

--- a/source/production/F0.Analyzers/CodeAnalysis/Diagnostics/F00001GoToStatementConsideredHarmful.cs
+++ b/source/production/F0.Analyzers/CodeAnalysis/Diagnostics/F00001GoToStatementConsideredHarmful.cs
@@ -5,7 +5,8 @@ namespace F0.CodeAnalysis.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed class F00001GoToStatementConsideredHarmful : DiagnosticAnalyzer
 {
-	private static readonly DiagnosticDescriptor Rule = new(
+	[SuppressMessage("Style", "IDE0090:Use 'new(...)'", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/5828")]
+	private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
 		DiagnosticIds.F00001,
 		"GotoConsideredHarmful",
 		"Don't use goto statements: '{0}'",

--- a/source/production/F0.Analyzers/CodeAnalysis/Diagnostics/F0100xPreferPatternMatchingNullCheckOverComparisonWithNull.cs
+++ b/source/production/F0.Analyzers/CodeAnalysis/Diagnostics/F0100xPreferPatternMatchingNullCheckOverComparisonWithNull.cs
@@ -10,7 +10,8 @@ internal sealed class F0100xPreferPatternMatchingNullCheckOverComparisonWithNull
 	private const string Title = "Prefer is pattern to check for null";
 	private const string Description = "When an expression is matched against the 'null' literal, the compiler guarantees that neither an overloaded operator nor an overridden method is invoked.";
 
-	internal static readonly DiagnosticDescriptor EqualityComparisonRule = new(
+	[SuppressMessage("Style", "IDE0090:Use 'new(...)'", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/5828")]
+	internal static readonly DiagnosticDescriptor EqualityComparisonRule = new DiagnosticDescriptor(
 		DiagnosticIds.F01001,
 		Title,
 		"Prefer '{0}' pattern over calling the (potentially) {1} '{2}' {3} to check for {4}",
@@ -21,7 +22,8 @@ internal sealed class F0100xPreferPatternMatchingNullCheckOverComparisonWithNull
 		DiagnosticHelpLinkUris.F01001
 	);
 
-	internal static readonly DiagnosticDescriptor IdentityComparisonRule = new(
+	[SuppressMessage("Style", "IDE0090:Use 'new(...)'", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/5828")]
+	internal static readonly DiagnosticDescriptor IdentityComparisonRule = new DiagnosticDescriptor(
 		DiagnosticIds.F01002,
 		Title,
 		"Prefer '{0}' pattern over calling the '{1}' {2} to check for {3}",

--- a/source/production/F0.Analyzers/CodeAnalysis/Diagnostics/F02001ImplicitRecordClassDeclaration.cs
+++ b/source/production/F0.Analyzers/CodeAnalysis/Diagnostics/F02001ImplicitRecordClassDeclaration.cs
@@ -5,7 +5,8 @@ namespace F0.CodeAnalysis.Diagnostics;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed class F02001ImplicitRecordClassDeclaration : DiagnosticAnalyzer
 {
-	private static readonly DiagnosticDescriptor Rule = new(
+	[SuppressMessage("Style", "IDE0090:Use 'new(...)'", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/5828")]
+	private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
 		DiagnosticIds.F02001,
 		"Implicit record class declaration",
 		"Record class '{0}' is declared implicitly",

--- a/source/production/F0.Analyzers/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.cs
+++ b/source/production/F0.Analyzers/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.cs
@@ -1,0 +1,160 @@
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace F0.CodeAnalysis.Suppressors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CA1707IdentifiersShouldNotContainUnderscoresSuppressor : DiagnosticSuppressor
+{
+	private static readonly SuppressionDescriptor Rule = new SuppressionDescriptor(
+		"F0CA1707",
+		"CA1707",
+		"Suppress CA1707 on test methods to allow the best practices naming standard for tests."
+	);
+
+	private static readonly SymbolDisplayFormat format = new(SymbolDisplayGlobalNamespaceStyle.Omitted, SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
+
+	public override void ReportSuppressions(SuppressionAnalysisContext context)
+	{
+		foreach (var diagnostic in context.ReportedDiagnostics)
+		{
+			ReportSuppression(diagnostic, context);
+		}
+	}
+
+	private static void ReportSuppression(Diagnostic diagnostic, SuppressionAnalysisContext context)
+	{
+		var location = diagnostic.Location;
+		Debug.Assert(location != Location.None, $"{nameof(Diagnostic)} '{diagnostic}' has no primary location.");
+
+		var syntaxTree = location.SourceTree;
+		Debug.Assert(syntaxTree is not null, $"{nameof(Location)} '{location}' is not in a syntax tree.");
+
+		var root = syntaxTree.GetRoot(context.CancellationToken);
+
+		var textSpan = location.SourceSpan;
+		Debug.Assert(location.IsInSource, $"{nameof(Location)} '{location}' does not represent a specific location in a source code file.");
+
+		var node = root.FindNode(textSpan);
+
+		if (node is not MethodDeclarationSyntax method)
+		{
+			return;
+		}
+
+		if (method.AttributeLists.Count == 0)
+		{
+			return;
+		}
+
+		var semanticModel = context.GetSemanticModel(syntaxTree);
+
+		if (IsTestMethod(semanticModel, method, context.CancellationToken))
+		{
+			var suppression = Suppression.Create(Rule, diagnostic);
+			context.ReportSuppression(suppression);
+		}
+	}
+
+	private static bool IsTestMethod(SemanticModel semanticModel, MethodDeclarationSyntax method, CancellationToken cancellationToken)
+	{
+		if (IsMSTest(semanticModel, method, cancellationToken))
+		{
+			return true;
+		}
+
+		var attributes = method.AttributeLists
+			.SelectMany(static list => list.Attributes);
+
+		foreach (var attribute in attributes)
+		{
+			var typeInfo = semanticModel.GetTypeInfo(attribute, cancellationToken);
+
+			Debug.Assert(typeInfo.Type is not null, $"Expression '{attribute}' does not have a type.");
+
+			if (typeInfo.Type is IErrorTypeSymbol)
+			{
+				continue;
+			}
+
+			Debug.Assert(typeInfo.Type is INamedTypeSymbol, $"Unexpected type '{typeInfo.Type.GetType()}' of {nameof(typeInfo.Type.Kind)} '{typeInfo.Type.Kind}'.");
+
+			if (IsNUnit(typeInfo.Type) || IsXunit(typeInfo.Type))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool IsMSTest(SemanticModel semanticModel, MethodDeclarationSyntax method, CancellationToken cancellationToken)
+	{
+		var symbol = semanticModel.GetDeclaredSymbol(method, cancellationToken);
+		Debug.Assert(symbol is not null, $"Couldn't retrieve the declared {nameof(IMethodSymbol)} of '{method}'.");
+
+		var hasTestMethodAttribute = false;
+		foreach (var attribute in symbol.GetAttributes())
+		{
+			Debug.Assert(attribute.AttributeClass is not null, $"{nameof(AttributeData)} '{attribute}' has no '{nameof(attribute.AttributeClass)}'.");
+
+			var display = attribute.AttributeClass.ToDisplayString(format);
+
+			if ((display.Equals("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute", StringComparison.Ordinal)
+				|| display.Equals("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute", StringComparison.Ordinal))
+				&& attribute.AttributeClass.ContainingAssembly.Identity.Name.StartsWith("Microsoft.VisualStudio", StringComparison.Ordinal))
+			{
+				hasTestMethodAttribute = true;
+				break;
+			}
+		}
+
+		if (!hasTestMethodAttribute)
+		{
+			return false;
+		}
+
+		var hasTestClassAttribute = false;
+		foreach (var attribute in symbol.ContainingType.GetAttributes())
+		{
+			Debug.Assert(attribute.AttributeClass is not null, $"{nameof(AttributeData)} '{attribute}' has no '{nameof(attribute.AttributeClass)}'.");
+
+			var display = attribute.AttributeClass.ToDisplayString(format);
+
+			if (display.Equals("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute", StringComparison.Ordinal)
+				&& attribute.AttributeClass.ContainingAssembly.Identity.Name.StartsWith("Microsoft.VisualStudio", StringComparison.Ordinal))
+			{
+				hasTestClassAttribute = true;
+				break;
+			}
+		}
+
+		return hasTestClassAttribute;
+	}
+
+	private static bool IsNUnit(ITypeSymbol attributeType)
+	{
+		var display = attributeType.ToString();
+		Debug.Assert(display is not null, $"Type '{attributeType}' has no display name.");
+
+		return attributeType.ContainingAssembly.Identity.Name.StartsWith("nunit")
+			&& (display.Equals("NUnit.Framework.TestAttribute", StringComparison.Ordinal)
+			|| display.Equals("NUnit.Framework.TestCaseAttribute", StringComparison.Ordinal)
+			|| display.Equals("NUnit.Framework.TestCaseSourceAttribute", StringComparison.Ordinal)
+			|| display.Equals("NUnit.Framework.CombinatorialAttribute", StringComparison.Ordinal)
+			|| display.Equals("NUnit.Framework.PairwiseAttribute", StringComparison.Ordinal)
+			|| display.Equals("NUnit.Framework.SequentialAttribute", StringComparison.Ordinal)
+			|| display.Equals("NUnit.Framework.TheoryAttribute", StringComparison.Ordinal));
+	}
+
+	private static bool IsXunit(ITypeSymbol attributeType)
+	{
+		var display = attributeType.ToString();
+		Debug.Assert(display is not null, $"Type '{attributeType}' has no display name.");
+
+		return attributeType.ContainingAssembly.Identity.Name.StartsWith("xunit")
+			&& (display.Equals("Xunit.FactAttribute", StringComparison.Ordinal)
+			|| display.Equals("Xunit.TheoryAttribute", StringComparison.Ordinal));
+	}
+}

--- a/source/production/F0.Analyzers/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.cs
+++ b/source/production/F0.Analyzers/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressor.cs
@@ -1,3 +1,4 @@
+using F0.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace F0.CodeAnalysis.Suppressors;
@@ -5,7 +6,7 @@ namespace F0.CodeAnalysis.Suppressors;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed class CA1707IdentifiersShouldNotContainUnderscoresSuppressor : DiagnosticSuppressor
 {
-	private static readonly SuppressionDescriptor Rule = new SuppressionDescriptor(
+	private static readonly SuppressionDescriptor Rule = new(
 		"F0CA1707",
 		"CA1707",
 		"Suppress CA1707 on test methods to allow the best practices naming standard for tests."
@@ -101,9 +102,9 @@ internal sealed class CA1707IdentifiersShouldNotContainUnderscoresSuppressor : D
 
 			var display = attribute.AttributeClass.ToDisplayString(format);
 
-			if ((display.Equals("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute", StringComparison.Ordinal)
-				|| display.Equals("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute", StringComparison.Ordinal))
-				&& attribute.AttributeClass.ContainingAssembly.Identity.Name.StartsWith("Microsoft.VisualStudio", StringComparison.Ordinal))
+			if ((display.EqualsOrdinal("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute")
+				|| display.EqualsOrdinal("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute"))
+				&& attribute.AttributeClass.ContainingAssembly.Identity.Name.StartsWithOrdinal("Microsoft.VisualStudio"))
 			{
 				hasTestMethodAttribute = true;
 				break;
@@ -122,8 +123,8 @@ internal sealed class CA1707IdentifiersShouldNotContainUnderscoresSuppressor : D
 
 			var display = attribute.AttributeClass.ToDisplayString(format);
 
-			if (display.Equals("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute", StringComparison.Ordinal)
-				&& attribute.AttributeClass.ContainingAssembly.Identity.Name.StartsWith("Microsoft.VisualStudio", StringComparison.Ordinal))
+			if (display.EqualsOrdinal("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute")
+				&& attribute.AttributeClass.ContainingAssembly.Identity.Name.StartsWithOrdinal("Microsoft.VisualStudio"))
 			{
 				hasTestClassAttribute = true;
 				break;
@@ -138,14 +139,14 @@ internal sealed class CA1707IdentifiersShouldNotContainUnderscoresSuppressor : D
 		var display = attributeType.ToString();
 		Debug.Assert(display is not null, $"Type '{attributeType}' has no display name.");
 
-		return attributeType.ContainingAssembly.Identity.Name.StartsWith("nunit")
-			&& (display.Equals("NUnit.Framework.TestAttribute", StringComparison.Ordinal)
-			|| display.Equals("NUnit.Framework.TestCaseAttribute", StringComparison.Ordinal)
-			|| display.Equals("NUnit.Framework.TestCaseSourceAttribute", StringComparison.Ordinal)
-			|| display.Equals("NUnit.Framework.CombinatorialAttribute", StringComparison.Ordinal)
-			|| display.Equals("NUnit.Framework.PairwiseAttribute", StringComparison.Ordinal)
-			|| display.Equals("NUnit.Framework.SequentialAttribute", StringComparison.Ordinal)
-			|| display.Equals("NUnit.Framework.TheoryAttribute", StringComparison.Ordinal));
+		return attributeType.ContainingAssembly.Identity.Name.StartsWithOrdinal("nunit")
+			&& (display.EqualsOrdinal("NUnit.Framework.TestAttribute")
+			|| display.EqualsOrdinal("NUnit.Framework.TestCaseAttribute")
+			|| display.EqualsOrdinal("NUnit.Framework.TestCaseSourceAttribute")
+			|| display.EqualsOrdinal("NUnit.Framework.CombinatorialAttribute")
+			|| display.EqualsOrdinal("NUnit.Framework.PairwiseAttribute")
+			|| display.EqualsOrdinal("NUnit.Framework.SequentialAttribute")
+			|| display.EqualsOrdinal("NUnit.Framework.TheoryAttribute"));
 	}
 
 	private static bool IsXunit(ITypeSymbol attributeType)
@@ -153,8 +154,8 @@ internal sealed class CA1707IdentifiersShouldNotContainUnderscoresSuppressor : D
 		var display = attributeType.ToString();
 		Debug.Assert(display is not null, $"Type '{attributeType}' has no display name.");
 
-		return attributeType.ContainingAssembly.Identity.Name.StartsWith("xunit")
-			&& (display.Equals("Xunit.FactAttribute", StringComparison.Ordinal)
-			|| display.Equals("Xunit.TheoryAttribute", StringComparison.Ordinal));
+		return attributeType.ContainingAssembly.Identity.Name.StartsWithOrdinal("xunit")
+			&& (display.EqualsOrdinal("Xunit.FactAttribute")
+			|| display.EqualsOrdinal("Xunit.TheoryAttribute"));
 	}
 }

--- a/source/production/F0.Analyzers/Extensions/StringExtensions.Comparison.cs
+++ b/source/production/F0.Analyzers/Extensions/StringExtensions.Comparison.cs
@@ -1,0 +1,10 @@
+namespace F0.Extensions;
+
+internal static class StringExtensions
+{
+	internal static bool EqualsOrdinal(this string left, string right)
+		=> left.Equals(right, StringComparison.Ordinal);
+
+	internal static bool StartsWithOrdinal(this string left, string right)
+		=> left.StartsWith(right, StringComparison.Ordinal);
+}

--- a/source/production/F0.Analyzers/F0.Analyzers.csproj
+++ b/source/production/F0.Analyzers/F0.Analyzers.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22081.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/source/production/F0.Analyzers/Properties/AssemblyInfo.cs
+++ b/source/production/F0.Analyzers/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
 
-[assembly: CLSCompliant(false)]
 [assembly: InternalsVisibleTo("F0.Analyzers.Benchmarks")]
 [assembly: InternalsVisibleTo("F0.Analyzers.Tests")]

--- a/source/test/.globalconfig
+++ b/source/test/.globalconfig
@@ -1,0 +1,13 @@
+is_global = true
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = none
+
+# CA1307: Specify StringComparison for clarity
+dotnet_diagnostic.CA1307.severity = none
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = none

--- a/source/test/F0.Analyzers.Tests/AssemblyInfoTests.cs
+++ b/source/test/F0.Analyzers.Tests/AssemblyInfoTests.cs
@@ -41,7 +41,7 @@ public class AssemblyInfoTests
 		var displayName = $"F0.Analyzers, Version={version}, Culture=neutral, PublicKeyToken=null";
 
 		var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-		var assembly = assemblies.Single(a => a.FullName.Equals(displayName, StringComparison.InvariantCulture));
+		var assembly = assemblies.Single(a => a.FullName.Equals(displayName, StringComparison.Ordinal));
 
 		return assembly;
 	}

--- a/source/test/F0.Analyzers.Tests/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressorTests.cs
+++ b/source/test/F0.Analyzers.Tests/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressorTests.cs
@@ -1,0 +1,556 @@
+using System.Reflection;
+using F0.CodeAnalysis.Suppressors;
+using F0.Testing.CodeAnalysis;
+using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines;
+
+namespace F0.Tests.CodeAnalysis.Suppressors;
+
+public class CA1707IdentifiersShouldNotContainUnderscoresSuppressorTests
+{
+	private static readonly DiagnosticResult CA1707 = DiagnosticResult.CompilerWarning("CA1707").WithSeverity(DiagnosticSeverity.Hidden);
+
+	[Fact]
+	public void CA1707IdentifiersShouldNotContainUnderscoresSuppressor_CheckType()
+		=> Verify.DiagnosticSuppressor<CA1707IdentifiersShouldNotContainUnderscoresSuppressor>().Type();
+
+	[Theory]
+	[InlineData(true, true, true, true)]
+	[InlineData(true, false, false, false)]
+	[InlineData(false, true, true, false)]
+	public async Task ReportSuppressions_MSTest_SuppressForTestMethods(bool useTestClassAttribute, bool useTestMethodAttribute, bool useDataTestMethodAttribute, bool isSuppressed)
+	{
+		var code =
+$@"using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+{(useTestClassAttribute ? "[TestClass]" : "")}
+public class MSTest
+{{
+	{(useTestMethodAttribute ? "[TestMethod]" : "")}
+	public void {{|#0:Given_When_Then|}}()
+	{{
+		Assert.AreEqual(240, 0x_F0);
+	}}
+
+	{(useDataTestMethodAttribute ? "[DataTestMethod]" : "")}
+	[DataRow(0x_F0)]
+	public void {{|#1:MethodUnderTest_Scenario_ExpectedResult|}}(int value)
+	{{
+		Assert.AreEqual(240, value);
+	}}
+}}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(isSuppressed),
+			CA1707.WithLocation(1).WithIsSuppressed(isSuppressed),
+		};
+
+		await VerifyAsync(code, expected, typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute));
+	}
+
+	[Theory]
+	[InlineData(true, false, true, false, true)]
+	[InlineData(true, false, false, true, true)]
+	[InlineData(false, false, true, false, true)]
+	[InlineData(false, false, false, true, true)]
+	[InlineData(false, true, true, false, true)]
+	[InlineData(false, true, false, true, true)]
+	public async Task ReportSuppressions_NUnit_SuppressForTestMethods(bool useTestFixtureAttribute, bool useTestAttribute, bool useTestCaseAttribute, bool useTestCaseSourceAttribute, bool isSuppressed)
+	{
+		var code =
+$@"using NUnit.Framework;
+
+{(useTestFixtureAttribute ? "[TestFixture]" : "")}
+public class NUnitTests
+{{
+	[Test]
+	public void {{|#0:Given_When_Then|}}()
+	{{
+		Assert.AreEqual(240, 0x_F0);
+	}}
+
+	{(useTestAttribute ? "[Test]" : "")}
+	{(useTestCaseAttribute ? "[TestCase(0x_F0)]" : "")}
+	{(useTestCaseSourceAttribute ? "[TestCaseSource(nameof(TestCaseSource))]" : "")}
+	public void {{|#1:MethodUnderTest_Scenario_ExpectedResult|}}(int value)
+	{{
+		Assert.AreEqual(240, value);
+	}}
+
+	private static int[] TestCaseSource => new int[] {{ 0x_F0 }};
+}}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(isSuppressed),
+			CA1707.WithLocation(1).WithIsSuppressed(isSuppressed),
+		};
+
+		await VerifyAsync(code, expected, typeof(NUnit.Framework.TestAttribute));
+	}
+
+	[Fact]
+	public async Task ReportSuppressions_NUnit_CombiningStrategyAttribute_SuppressForTestMethods()
+	{
+		var code =
+@"using NUnit.Framework;
+
+public class NUnitTests
+{
+	[Combinatorial]
+	public void {|#0:Combinatorial_Attribute|}([Values(1, 2)] int number, [Values(""A"", ""B"")] string text)
+	{
+	}
+
+	[Pairwise]
+	public void {|#1:Pairwise_Attribute|}([Values(""a"", ""b"", ""c"")] string left, [Values(""+"", ""-"")] string middle, [Values(""x"", ""y"")] string right)
+	{
+	}
+
+	[Sequential]
+	public void {|#2:Sequential_Attribute|}([Values(1, 2, 3)] int number, [Values(""A"", ""B"")] string text)
+	{
+	}
+
+	[Theory]
+	public void {|#3:Theory_Attribute|}(int number)
+	{
+	}
+
+	[DatapointSource]
+	public int[] DatapointSource => new int[] { -1, 0, 1 };
+}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(true),
+			CA1707.WithLocation(1).WithIsSuppressed(true),
+			CA1707.WithLocation(2).WithIsSuppressed(true),
+			CA1707.WithLocation(3).WithIsSuppressed(true),
+		};
+
+		await VerifyAsync(code, expected, typeof(NUnit.Framework.CombiningStrategyAttribute));
+	}
+
+	[Fact]
+	public async Task ReportSuppressions_xUnit_SuppressForTestMethods()
+	{
+		var code =
+@"using Xunit;
+
+public class xUnit
+{
+	[Fact]
+	public void {|#0:Given_When_Then|}()
+	{
+		Assert.Equal(240, 0x_F0);
+	}
+
+	[Theory]
+	[InlineData(0x_F0)]
+	public void {|#1:MethodUnderTest_Scenario_ExpectedResult|}(int value)
+	{
+		Assert.Equal(240, value);
+	}
+}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(true),
+			CA1707.WithLocation(1).WithIsSuppressed(true),
+		};
+
+		await VerifyAsync(code, expected, typeof(FactAttribute), typeof(Xunit.Assert));
+	}
+
+	[Fact]
+	public async Task ReportSuppressions_NonTestMethods_NoOp()
+	{
+		var code =
+@"using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Xunit;
+
+[TestClass]
+public class MSTest
+{
+	[TestMethod]
+	public void {|#0:Given_When_Then|}() { }
+
+	[DataTestMethod]
+	[DataRow(0x_F0)]
+	public void {|#1:MethodUnderTest_Scenario_ExpectedResult|}(int value) { }
+}
+
+[TestFixture]
+public class NUnitTests
+{
+	[Test]
+	public void {|#2:Given_When_Then|}() { }
+
+	[TestCase(0x_F0)]
+	[TestCaseSource(nameof(TestCaseSource))]
+	public void {|#3:MethodUnderTest_Scenario_ExpectedResult|}(int value) { }
+
+	private static int[] TestCaseSource => new int[] { 0x_F0 };
+}
+
+public class NUnitCombiningStrategyAttribute
+{
+	[Combinatorial]
+	public void {|#4:Combinatorial_Attribute|}() { }
+
+	[Pairwise]
+	public void {|#5:Pairwise_Attribute|}() { }
+
+	[Sequential]
+	public void {|#6:Sequential_Attribute|}() { }
+
+	[NUnit.Framework.Theory]
+	public void {|#7:Theory_Attribute|}(int number) { }
+
+	[DatapointSource]
+	public int[] DatapointSource => new int[] { 0x_F0 };
+}
+
+public class xUnit
+{
+	[Fact]
+	public void {|#8:Given_When_Then|}() { }
+
+	[Xunit.Theory]
+	[InlineData(0x_F0)]
+	public void {|#9:MethodUnderTest_Scenario_ExpectedResult|}(int value) { }
+}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(false),
+			CA1707.WithLocation(1).WithIsSuppressed(false),
+			CA1707.WithLocation(2).WithIsSuppressed(false),
+			CA1707.WithLocation(3).WithIsSuppressed(false),
+			CA1707.WithLocation(4).WithIsSuppressed(false),
+			CA1707.WithLocation(5).WithIsSuppressed(false),
+			CA1707.WithLocation(6).WithIsSuppressed(false),
+			CA1707.WithLocation(7).WithIsSuppressed(false),
+			CA1707.WithLocation(8).WithIsSuppressed(false),
+			CA1707.WithLocation(9).WithIsSuppressed(false),
+		};
+
+		var attributes =
+@"using System;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting
+{
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+	public class TestClassAttribute : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class TestMethodAttribute : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class DataTestMethodAttribute : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public class DataRowAttribute : Attribute
+	{
+		public DataRowAttribute(object data1) => throw null;
+	}
+}
+
+namespace NUnit.Framework
+{
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+	public class TestFixtureAttribute : NUnitAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+	public class TestAttribute : NUnitAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+	public class TestCaseAttribute : NUnitAttribute
+	{
+		public TestCaseAttribute(object? arg) => throw null;
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+	public class TestCaseSourceAttribute : NUnitAttribute
+	{
+		public TestCaseSourceAttribute(string sourceName) => throw null;
+	}
+
+	public abstract class NUnitAttribute : Attribute
+	{
+	}
+}
+
+namespace NUnit.Framework
+{
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+	public class CombinatorialAttribute : CombiningStrategyAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+	public class PairwiseAttribute : CombiningStrategyAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+	public class SequentialAttribute : CombiningStrategyAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+	public class TheoryAttribute : CombiningStrategyAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+	public abstract class CombiningStrategyAttribute : NUnitAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+	public class DatapointSourceAttribute : NUnitAttribute
+	{
+	}
+}
+
+namespace Xunit
+{
+	using Xunit.Sdk;
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class FactAttribute : Attribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class TheoryAttribute : FactAttribute
+	{
+	}
+
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public sealed class InlineDataAttribute : DataAttribute
+	{
+		public InlineDataAttribute(params object[] data) => throw null;
+	}
+}
+
+namespace Xunit.Sdk
+{
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+	public abstract class DataAttribute : Attribute
+	{
+	}
+}";
+
+		await VerifyAsync(code, expected, attributes);
+	}
+
+	[Fact]
+	public async Task ReportSuppressions_Alias_SuppressForTestMethods()
+	{
+		var code =
+@"using System;
+using MSTestAlias1 = Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+using MSTestAlias2 = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+using MSTestAlias3 = Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute;
+using MSTestAlias4 = Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute;
+using NUnitAlias1 = NUnit.Framework.TestFixtureAttribute;
+using NUnitAlias2 = NUnit.Framework.TestAttribute;
+using NUnitAlias3 = NUnit.Framework.TestCaseAttribute;
+using NUnitAlias4 = NUnit.Framework.TestCaseSourceAttribute;
+using NUnitAlias5 = NUnit.Framework.CombinatorialAttribute;
+using NUnitAlias6 = NUnit.Framework.PairwiseAttribute;
+using NUnitAlias7 = NUnit.Framework.SequentialAttribute;
+using NUnitAlias8 = NUnit.Framework.TheoryAttribute;
+using XunitAlias1 = Xunit.FactAttribute;
+using XunitAlias2 = Xunit.TheoryAttribute;
+using XunitAlias3 = Xunit.InlineDataAttribute;
+
+[MSTestAlias1]
+public class MSTest
+{
+	[MSTestAlias2]
+	public void {|#0:Alias_MSTest_TestMethodAttribute|}() { }
+
+	[MSTestAlias3]
+	[MSTestAlias4(0x_F0)]
+	public void {|#1:Alias_MSTest_DataTestMethodAttribute|}(int value) { }
+}
+
+[NUnitAlias1]
+public class NUnitTests
+{
+	[NUnitAlias2]
+	public void {|#2:Alias_NUnit_TestAttribute|}() { }
+
+	[NUnitAlias3(0x_F0)]
+	public void {|#3:Alias_NUnit_TestCaseAttribute|}(int value) { }
+
+	[NUnitAlias4(nameof(TestCaseSource))]
+	public void {|#4:Alias_NUnit_TestCaseSourceAttribute|}(int value)
+	{
+	}
+
+	private static int[] TestCaseSource => new int[] { 0x_F0 };
+}
+
+public class NUnitCombiningStrategyAttribute
+{
+	[NUnitAlias5]
+	public void {|#5:Alias_NUnit_CombinatorialAttribute|}() { }
+
+	[NUnitAlias6]
+	public void {|#6:Alias_NUnit_PairwiseAttribute|}() { }
+
+	[NUnitAlias7]
+	public void {|#7:Alias_NUnit_SequentialAttribute|}() { }
+
+	[NUnitAlias8]
+	public void {|#8:Alias_NUnit_TheoryAttribute|}() { }
+}
+
+public class xUnit
+{
+	[XunitAlias1]
+	public void {|#9:Alias_xUnit_FactAttribute|}() { }
+
+	[XunitAlias2]
+	[XunitAlias3(0x_F0)]
+	public void {|#10:Alias_xUnit_TheoryAttribute|}(int value) { }
+}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(true),
+			CA1707.WithLocation(1).WithIsSuppressed(true),
+			CA1707.WithLocation(2).WithIsSuppressed(true),
+			CA1707.WithLocation(3).WithIsSuppressed(true),
+			CA1707.WithLocation(4).WithIsSuppressed(true),
+			CA1707.WithLocation(5).WithIsSuppressed(true),
+			CA1707.WithLocation(6).WithIsSuppressed(true),
+			CA1707.WithLocation(7).WithIsSuppressed(true),
+			CA1707.WithLocation(8).WithIsSuppressed(true),
+			CA1707.WithLocation(9).WithIsSuppressed(true),
+			CA1707.WithLocation(10).WithIsSuppressed(true),
+		};
+
+		await VerifyAsync(code, expected, typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute), typeof(NUnit.Framework.TestAttribute), typeof(FactAttribute));
+	}
+
+	[Fact]
+	public async Task ReportSuppressions_NonTestMethods_DoNotSuppress()
+	{
+		var code =
+@"using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
+using Xunit;
+
+namespace {|#0:My_Namespace|};
+
+[TestClass]
+public class {|#1:MSTest_Tests|}
+{
+	[AssemblyInitialize]
+	public static void {|#2:Assembly_Initialize|}(TestContext context) => throw null;
+
+	[ClassInitialize]
+	public static void {|#3:Class_Initialize|}(TestContext context) => throw null;
+
+	[TestInitialize]
+	public void {|#4:Test_Initialize|}() => throw null;
+
+	[DataTestMethod]
+	[DataRow(0x_F0)]
+	public void TestMethod(int {|#5:method_parameter|}) => throw null;
+
+	[TestCleanup]
+	public void {|#6:Test_Cleanup|}() => throw null;
+
+	[ClassCleanup]
+	public static void {|#7:Class_Cleanup|}() => throw null;
+
+	[AssemblyCleanup]
+	public static void {|#8:Assembly_Cleanup|}() => throw null;
+}
+
+[TestFixture]
+public class {|#9:NUnit_Tests|}
+{
+	[SetUp]
+	public void {|#10:SetUp_Attribute|}() => throw null;
+
+	[TestCase(0x_F0)]
+	public void TestCase(int {|#11:method_parameter|}) => throw null;
+
+	[TearDown]
+	public void {|#12:TearDown_Attribute|}() => throw null;
+}
+
+public class {|#13:xUnit_Tests|} : IDisposable
+{
+	public xUnit_Tests() => throw null;
+
+	[Xunit.Theory]
+	[InlineData(0x_F0)]
+	public void Theory(int {|#14:method_parameter|}) => throw null;
+
+	public void Dispose() => throw null;
+}
+
+public class MyClass<{|#15:Type_TypeParameter|}>
+{
+	public int {|#16:My_Property|} { get; set; }
+
+	public void MyMethod<{|#17:Method_TypeParameter|}>() => throw null;
+}";
+
+		var expected = new[]
+		{
+			CA1707.WithLocation(0).WithIsSuppressed(false),
+			CA1707.WithLocation(1).WithIsSuppressed(false),
+			CA1707.WithLocation(2).WithIsSuppressed(false),
+			CA1707.WithLocation(3).WithIsSuppressed(false),
+			CA1707.WithLocation(4).WithIsSuppressed(false),
+			CA1707.WithLocation(5).WithIsSuppressed(false),
+			CA1707.WithLocation(6).WithIsSuppressed(false),
+			CA1707.WithLocation(7).WithIsSuppressed(false),
+			CA1707.WithLocation(8).WithIsSuppressed(false),
+			CA1707.WithLocation(9).WithIsSuppressed(false),
+			CA1707.WithLocation(10).WithIsSuppressed(false),
+			CA1707.WithLocation(11).WithIsSuppressed(false),
+			CA1707.WithLocation(12).WithIsSuppressed(false),
+			CA1707.WithLocation(13).WithIsSuppressed(false),
+			CA1707.WithLocation(14).WithIsSuppressed(false),
+			CA1707.WithLocation(15).WithIsSuppressed(false),
+			CA1707.WithLocation(16).WithIsSuppressed(false),
+			CA1707.WithLocation(17).WithIsSuppressed(false),
+			CA1707.WithLocation(1, 1).WithIsSuppressed(false).WithArguments("My_Assembly"),
+		};
+
+		await VerifyAsync(code, "My_Assembly", expected, typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute), typeof(NUnit.Framework.TestAttribute), typeof(FactAttribute));
+	}
+
+	private static Task VerifyAsync(string code, DiagnosticResult[] diagnostics, params string[] additionalDocuments)
+		=> Verify.DiagnosticSuppressor<CA1707IdentifiersShouldNotContainUnderscoresSuppressor, IdentifiersShouldNotContainUnderscoresAnalyzer>().SuppressionAsync(code, diagnostics, ReferenceAssemblies.NetStandard.NetStandard20, new string[][] { additionalDocuments });
+
+	private static Task VerifyAsync(string code, DiagnosticResult[] diagnostics, params Type[] metadataReference)
+		=> Verify.DiagnosticSuppressor<CA1707IdentifiersShouldNotContainUnderscoresSuppressor, IdentifiersShouldNotContainUnderscoresAnalyzer>().SuppressionAsync(code, diagnostics, ReferenceAssemblies.NetStandard.NetStandard20, metadataReference);
+
+	private static Task VerifyAsync(string code, string assemblyName, DiagnosticResult[] diagnostics, params Type[] metadataReference)
+		=> Verify.DiagnosticSuppressor<CA1707IdentifiersShouldNotContainUnderscoresSuppressor, IdentifiersShouldNotContainUnderscoresAnalyzer>().SuppressionAsync(code, diagnostics, ReferenceAssemblies.NetStandard.NetStandard20, metadataReference, new AssemblyName(assemblyName));
+}

--- a/source/test/F0.Analyzers.Tests/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressorTests.cs
+++ b/source/test/F0.Analyzers.Tests/CodeAnalysis/Suppressors/CA1707IdentifiersShouldNotContainUnderscoresSuppressorTests.cs
@@ -517,10 +517,14 @@ public class MyClass<{|#15:Type_TypeParameter|}>
 	public int {|#16:My_Property|} { get; set; }
 
 	public void MyMethod<{|#17:Method_TypeParameter|}>() => throw null;
-}";
+}
+
+public delegate void Action<in T>(T {|#18:delegate_parameter|});
+";
 
 		var expected = new[]
 		{
+			CA1707.WithLocation(1, 1).WithIsSuppressed(false).WithArguments("My_Assembly"),
 			CA1707.WithLocation(0).WithIsSuppressed(false),
 			CA1707.WithLocation(1).WithIsSuppressed(false),
 			CA1707.WithLocation(2).WithIsSuppressed(false),
@@ -539,7 +543,7 @@ public class MyClass<{|#15:Type_TypeParameter|}>
 			CA1707.WithLocation(15).WithIsSuppressed(false),
 			CA1707.WithLocation(16).WithIsSuppressed(false),
 			CA1707.WithLocation(17).WithIsSuppressed(false),
-			CA1707.WithLocation(1, 1).WithIsSuppressed(false).WithArguments("My_Assembly"),
+			CA1707.WithLocation(18).WithIsSuppressed(false),
 		};
 
 		await VerifyAsync(code, "My_Assembly", expected, typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute), typeof(NUnit.Framework.TestAttribute), typeof(FactAttribute));

--- a/source/test/F0.Analyzers.Tests/Extensions/StringExtensionsTests.Comparison.cs
+++ b/source/test/F0.Analyzers.Tests/Extensions/StringExtensionsTests.Comparison.cs
@@ -1,0 +1,64 @@
+using F0.Extensions;
+
+namespace F0.Tests.Extensions;
+
+public class StringExtensionsTests
+{
+	[Fact]
+	public void EqualsOrdinal_EqualStrings_True()
+	{
+		// Arrange
+		var left = "Straße";
+		var right = "Straße";
+
+		// Act
+		var equals = left.EqualsOrdinal(right);
+
+		// Assert
+		equals.Should().BeTrue();
+	}
+
+	[Fact]
+	public void EqualsOrdinal_NotEqualStrings_False()
+	{
+		// Arrange
+		var left = "Straße";
+		var right = "Strasse";
+
+		// Act
+		var equals = left.EqualsOrdinal(right);
+
+		// Assert
+		equals.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData("Straße", "Straße")]
+	[InlineData("Straßenname", "Straße")]
+	public void StartsWithOrdinal_EqualStrings_True(string left, string right)
+	{
+		// Arrange
+
+		// Act
+		var equals = left.StartsWithOrdinal(right);
+
+		// Assert
+		equals.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData("Strasse", "Straße")]
+	[InlineData("Strassenname", "Straße")]
+	[InlineData("die Straße", "Straße")]
+	[InlineData("die Strasse", "Straße")]
+	public void StartsWithOrdinal_NotEqualStrings_False(string left, string right)
+	{
+		// Arrange
+
+		// Act
+		var equals = left.StartsWithOrdinal(right);
+
+		// Assert
+		equals.Should().BeFalse();
+	}
+}

--- a/source/test/F0.Analyzers.Tests/F0.Analyzers.Tests.csproj
+++ b/source/test/F0.Analyzers.Tests/F0.Analyzers.Tests.csproj
@@ -7,6 +7,10 @@
     <RootNamespace>F0.Tests</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.0" PrivateAssets="all" />
     <PackageReference Include="FakeItEasy" Version="7.0.1" />
@@ -18,7 +22,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
+    <Reference Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/test/F0.Analyzers.Tests/Properties/AssemblyInfo.cs
+++ b/source/test/F0.Analyzers.Tests/Properties/AssemblyInfo.cs
@@ -1,2 +1,1 @@
-
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerClass)]

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/CodeFixes/CodeFixVerifier.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/CodeFixes/CodeFixVerifier.cs
@@ -89,7 +89,7 @@ public class CodeFixVerifier<TDiagnosticAnalyzer, TCodeFix>
 		var tester = new CodeFixTester<TDiagnosticAnalyzer, TCodeFix>
 		{
 			TestCode = normalizedInitialCode,
-			FixedCode = expectedCode is null ? normalizedInitialCode : expectedCode.Untabify()
+			FixedCode = expectedCode is null ? normalizedInitialCode : expectedCode.Untabify(),
 		};
 
 		if (referenceAssemblies is not null)

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/CodeRefactorings/CodeRefactoringVerifier.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/CodeRefactorings/CodeRefactoringVerifier.cs
@@ -76,7 +76,7 @@ public class CodeRefactoringVerifier<TCodeRefactoring>
 		var tester = new CodeRefactoringTester<TCodeRefactoring>
 		{
 			TestCode = normalizedInitialCode,
-			FixedCode = expectedCode is null ? normalizedInitialCode : expectedCode.Untabify()
+			FixedCode = expectedCode is null ? normalizedInitialCode : expectedCode.Untabify(),
 		};
 
 		if (languageVersion.HasValue)

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/DiagnosticSeverityExtensions.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/DiagnosticSeverityExtensions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+
+namespace F0.Testing.CodeAnalysis;
+
+internal static class DiagnosticSeverityExtensions
+{
+	public static ReportDiagnostic ToReportDiagnostic(this DiagnosticSeverity severity)
+	{
+		return severity switch
+		{
+			DiagnosticSeverity.Hidden => ReportDiagnostic.Hidden,
+			DiagnosticSeverity.Info => ReportDiagnostic.Info,
+			DiagnosticSeverity.Warning => ReportDiagnostic.Warn,
+			DiagnosticSeverity.Error => ReportDiagnostic.Error,
+			_ => throw new InvalidEnumArgumentException(nameof(severity), (int)severity, typeof(DiagnosticSeverity)),
+		};
+	}
+}

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Diagnostics/DiagnosticAnalyzerVerifier.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Diagnostics/DiagnosticAnalyzerVerifier.cs
@@ -73,7 +73,7 @@ public class DiagnosticAnalyzerVerifier<TDiagnosticAnalyzer>
 	{
 		var tester = new DiagnosticAnalyzerTester<TDiagnosticAnalyzer>
 		{
-			TestCode = code.Untabify()
+			TestCode = code.Untabify(),
 		};
 
 		if (languageVersion.HasValue)

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Documents.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Documents.cs
@@ -5,11 +5,11 @@ namespace F0.Testing.CodeAnalysis;
 /// </summary>
 public static class Documents
 {
-	public static readonly string FilePath = "/0/Test0.cs";
+	public const string FilePath = "/0/Test0.cs";
 
-	internal static readonly string Extension = ".cs";
+	internal const string Extension = ".cs";
 
-	private static readonly string DocumentFormat = "/{0}/Test{1}.cs";
+	private const string DocumentFormat = "/{0}/Test{1}.cs";
 
 	public static string CreateDocumentName(int projectIndex, int documentIndex)
 		=> String.Format(DocumentFormat, projectIndex + 1, documentIndex);

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Projects.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Projects.cs
@@ -5,9 +5,9 @@ namespace F0.Testing.CodeAnalysis;
 /// </summary>
 public static class Projects
 {
-	public static readonly string AssemblyName = "TestProject";
+	public const string AssemblyName = "TestProject";
 
-	internal static readonly string Extension = ".csproj";
+	internal const string Extension = ".csproj";
 
 	public static string CreateProjectName(int projectIndex)
 		=> AssemblyName + projectIndex;

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/SolutionStateExtensions.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/SolutionStateExtensions.cs
@@ -15,6 +15,7 @@ internal static class SolutionStateExtensions
 			{
 				OutputKind = OutputKind.DynamicallyLinkedLibrary,
 				DocumentationMode = DocumentationMode.Diagnose,
+				ReferenceAssemblies = solution.ReferenceAssemblies,
 			};
 
 			for (var documentIndex = 0; documentIndex < additionalDocuments.Length; documentIndex++)

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Suppressors/DiagnosticSuppressorTester.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Suppressors/DiagnosticSuppressorTester.cs
@@ -1,0 +1,56 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace F0.Testing.CodeAnalysis.Suppressors;
+
+internal class DiagnosticSuppressorTester<TDiagnosticSuppressor, TDiagnosticAnalyzer> : CSharpAnalyzerTest<TDiagnosticSuppressor, XUnitVerifier>
+	where TDiagnosticSuppressor : DiagnosticSuppressor, new()
+	where TDiagnosticAnalyzer : DiagnosticAnalyzer, new()
+{
+	private readonly TDiagnosticAnalyzer analyzer = new();
+
+	public DiagnosticSuppressorTester(IEnumerable<Type> metadataReferences)
+	{
+		TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck;
+
+		var diagnosticOptions = analyzer.SupportedDiagnostics
+			.ToImmutableDictionary(static descriptor => descriptor.Id, static descriptor => descriptor.DefaultSeverity.ToReportDiagnostic());
+
+		SolutionTransforms.Add((solution, projectId) =>
+		{
+			foreach (var metadataReference in metadataReferences)
+			{
+				var assemblyLocation = metadataReference.Assembly.Location;
+
+				solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(assemblyLocation));
+			}
+
+			var project = solution.GetProject(projectId);
+
+			var compilationOptions = (CSharpCompilationOptions)project.CompilationOptions;
+
+			compilationOptions = compilationOptions
+				.WithGeneralDiagnosticOption(ReportDiagnostic.Warn)
+				.WithSpecificDiagnosticOptions(diagnosticOptions)
+				.WithNullableContextOptions(NullableContextOptions.Enable);
+
+			solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+			return solution;
+		});
+
+		DiagnosticVerifier = (diagnostic, result, verifier) =>
+		{
+			var expected = result.IsSuppressed.GetValueOrDefault();
+
+			verifier.Equal(expected, diagnostic.IsSuppressed, $"{nameof(Diagnostic)} {result} is expected to be{(expected ? "" : " not")} suppressed.");
+		};
+	}
+
+	protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
+	{
+		var analyzers = new[] { analyzer };
+
+		return base.GetDiagnosticAnalyzers().Concat(analyzers);
+	}
+}

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Suppressors/DiagnosticSuppressorVerifier.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Suppressors/DiagnosticSuppressorVerifier.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using F0.Testing.Extensions;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace F0.Testing.CodeAnalysis.Suppressors;
+
+public class DiagnosticSuppressorVerifier<TDiagnosticSuppressor>
+	where TDiagnosticSuppressor : DiagnosticAnalyzer, new()
+{
+	internal DiagnosticSuppressorVerifier()
+	{
+	}
+
+	public void Type()
+	{
+		var type = typeof(TDiagnosticSuppressor);
+
+		type.VerifyAccessibility();
+		type.VerifyNonInheritable();
+		type.VerifyDiagnosticAnalyzerAttribute();
+	}
+}
+
+public class DiagnosticSuppressorVerifier<TDiagnosticSuppressor, TDiagnosticAnalyzer>
+	where TDiagnosticSuppressor : DiagnosticSuppressor, new()
+	where TDiagnosticAnalyzer : DiagnosticAnalyzer, new()
+{
+	internal DiagnosticSuppressorVerifier()
+	{
+	}
+
+	public Task SuppressionAsync(string code, IEnumerable<DiagnosticResult> diagnostics, ReferenceAssemblies referenceAssemblies, string[][] additionalProjects)
+	{
+		var tester = CreateTester(code, referenceAssemblies, additionalProjects, null);
+
+		tester.ExpectedDiagnostics.AddRange(diagnostics);
+
+		return tester.RunAsync(CancellationToken.None);
+	}
+
+	public Task SuppressionAsync(string code, IEnumerable<DiagnosticResult> diagnostics, ReferenceAssemblies referenceAssemblies, IEnumerable<Type> metadataReferences)
+	{
+		var tester = CreateTester(code, referenceAssemblies, null, metadataReferences);
+
+		tester.ExpectedDiagnostics.AddRange(diagnostics);
+
+		return tester.RunAsync(CancellationToken.None);
+	}
+
+	public Task SuppressionAsync(string code, IEnumerable<DiagnosticResult> diagnostics, ReferenceAssemblies referenceAssemblies, IEnumerable<Type> metadataReferences, AssemblyName name)
+	{
+		var tester = CreateTester(code, referenceAssemblies, null, metadataReferences);
+
+		tester.ExpectedDiagnostics.AddRange(diagnostics);
+
+		tester.SolutionTransforms.Add((solution, projectId) =>
+		{
+			solution = solution.WithProjectAssemblyName(projectId, name.Name);
+
+			return solution;
+		});
+
+		return tester.RunAsync(CancellationToken.None);
+	}
+
+	private static DiagnosticSuppressorTester<TDiagnosticSuppressor, TDiagnosticAnalyzer> CreateTester(string code, ReferenceAssemblies? referenceAssemblies = null, string[][]? additionalProjects = null, IEnumerable<Type>? metadataReferences = null)
+	{
+		metadataReferences ??= Array.Empty<Type>();
+
+		var tester = new DiagnosticSuppressorTester<TDiagnosticSuppressor, TDiagnosticAnalyzer>(metadataReferences)
+		{
+			TestCode = code.Untabify(),
+		};
+
+		if (referenceAssemblies is not null)
+		{
+			tester.TestState.ReferenceAssemblies = referenceAssemblies;
+		}
+
+		if (additionalProjects is not null)
+		{
+			tester.TestState.AddAdditionalProjects(additionalProjects);
+		}
+
+		return tester;
+	}
+}

--- a/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Verify.cs
+++ b/source/test/F0.CodeAnalysis.Testing/CodeAnalysis/Verify.cs
@@ -1,6 +1,7 @@
 using F0.Testing.CodeAnalysis.CodeFixes;
 using F0.Testing.CodeAnalysis.CodeRefactorings;
 using F0.Testing.CodeAnalysis.Diagnostics;
+using F0.Testing.CodeAnalysis.Suppressors;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -25,6 +26,15 @@ public static class Verify
 	public static CodeRefactoringVerifier<TCodeRefactoring> CodeRefactoring<TCodeRefactoring>()
 		where TCodeRefactoring : CodeRefactoringProvider, new()
 		=> new CodeRefactoringVerifier<TCodeRefactoring>();
+
+	public static DiagnosticSuppressorVerifier<TDiagnosticSuppressor> DiagnosticSuppressor<TDiagnosticSuppressor>()
+		where TDiagnosticSuppressor : DiagnosticSuppressor, new()
+		=> new DiagnosticSuppressorVerifier<TDiagnosticSuppressor>();
+
+	public static DiagnosticSuppressorVerifier<TDiagnosticSuppressor, TDiagnosticAnalyzer> DiagnosticSuppressor<TDiagnosticSuppressor, TDiagnosticAnalyzer>()
+		where TDiagnosticSuppressor : DiagnosticSuppressor, new()
+		where TDiagnosticAnalyzer : DiagnosticAnalyzer, new()
+		=> new DiagnosticSuppressorVerifier<TDiagnosticSuppressor, TDiagnosticAnalyzer>();
 
 	public static DiagnosticResult Diagnostic<TDiagnosticAnalyzer>(string diagnosticId)
 		where TDiagnosticAnalyzer : DiagnosticAnalyzer, new()

--- a/source/test/F0.CodeAnalysis.Testing/F0.CodeAnalysis.Testing.csproj
+++ b/source/test/F0.CodeAnalysis.Testing/F0.CodeAnalysis.Testing.csproj
@@ -7,14 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.0.1-beta1.20623.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20623.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.0.1-beta1.20623.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ImplicitUsings)' == 'true' Or '$(ImplicitUsings)' == 'enable'">


### PR DESCRIPTION
closes #96

Changes
- add suppressor to allow underscores in well-known unit test methods
  - update `Microsoft.CodeAnalysis.Testing` packages
  - add Testing types for `DiagnosticSuppressor`s
    - see also dotnet/roslyn-sdk/issues/942
  - add Benchmarking types for `DiagnosticSuppressor`s
  - add unit test example project
- enable all .NET analyzers for all projects
  - suppress some rules via `.globalconfig` if not applicable to project type
- fix false positives of `Microsoft.CodeAnalysis.Analyzers`
  - _RS1024_, see dotnet/roslyn-analyzers/issues/5715
  - _RS2003_, see dotnet/roslyn-analyzers/issues/5828
- some other cleanup and formatting
  - i.a. use trailing comma in object initializers, to make future changes git history friendly

Facts
- `DiagnosticSuppressor`s are available since _Roslyn 3.3.1_
