### PR TITLE
test: use fluent null check in nullable context

### DIFF
--- a/source/test/F0.Analyzers.Tests/AssemblyInfoTests.cs
+++ b/source/test/F0.Analyzers.Tests/AssemblyInfoTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Resources;
 using F0.CodeAnalysis.Diagnostics;
+using F0.Tests.Assertions;
 
 namespace F0.Tests;
 
@@ -20,8 +21,7 @@ public class AssemblyInfoTests
 		var assembly = GetAnalyzerAssembly();
 		var attribute = assembly.GetCustomAttribute<NeutralResourcesLanguageAttribute>();
 
-		attribute.Should().NotBeNull();
-		Debug.Assert(attribute is not null);
+		attribute.ShouldNotBeNull("custom attribute expected");
 		attribute.CultureName.Should().Be("en");
 		attribute.Location.Should().Be(UltimateResourceFallbackLocation.MainAssembly);
 	}
@@ -32,8 +32,7 @@ public class AssemblyInfoTests
 		var assembly = GetAnalyzerAssembly();
 		var attribute = assembly.GetCustomAttribute<CLSCompliantAttribute>();
 
-		attribute.Should().NotBeNull();
-		Debug.Assert(attribute is not null);
+		attribute.ShouldNotBeNull("custom attribute expected");
 		attribute.IsCompliant.Should().BeFalse();
 	}
 

--- a/source/test/F0.Analyzers.Tests/Assertions/AssertionExtensions.cs
+++ b/source/test/F0.Analyzers.Tests/Assertions/AssertionExtensions.cs
@@ -1,14 +1,12 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace F0.Tests.Assertions;
 
 internal static class AssertionExtensions
 {
+#pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
 	internal static void ShouldNotBeNull<T>([NotNull] this T reference, string because = "", params object[] becauseArgs)
 		where T : class?
-	{
-		_ = reference.Should().NotBeNull(because, becauseArgs);
-		Debug.Assert(reference is not null, "Unreachable");
-	}
+		=> _ = reference.Should().NotBeNull(because, becauseArgs);
+#pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 }

--- a/source/test/F0.Analyzers.Tests/Assertions/AssertionExtensions.cs
+++ b/source/test/F0.Analyzers.Tests/Assertions/AssertionExtensions.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace F0.Tests.Assertions;
+
+internal static class AssertionExtensions
+{
+	internal static void ShouldNotBeNull<T>([NotNull] this T reference, string because = "", params object[] becauseArgs)
+		where T : class?
+	{
+		_ = reference.Should().NotBeNull(because, becauseArgs);
+		Debug.Assert(reference is not null, "Unreachable");
+	}
+}

--- a/source/test/F0.CodeAnalysis.Testing/Extensions/TypeExtensions.Verify.cs
+++ b/source/test/F0.CodeAnalysis.Testing/Extensions/TypeExtensions.Verify.cs
@@ -1,5 +1,4 @@
 using System.Composition;
-using System.Diagnostics;
 using System.Reflection;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -23,7 +22,6 @@ internal static class TypeExtensions
 		var attribute = type.GetCustomAttribute<SharedAttribute>();
 
 		Assert.False(attribute is null, "Missing 'Shared' attribute.");
-		Debug.Assert(attribute is not null);
 		Assert.Null(attribute.SharingBoundary);
 	}
 
@@ -32,7 +30,6 @@ internal static class TypeExtensions
 		var attribute = type.GetCustomAttribute<DiagnosticAnalyzerAttribute>();
 
 		Assert.False(attribute is null, "Missing 'DiagnosticAnalyzer' attribute.");
-		Debug.Assert(attribute is not null);
 		Assert.Equal(cSharp, attribute.Languages);
 	}
 
@@ -41,7 +38,6 @@ internal static class TypeExtensions
 		var attribute = type.GetCustomAttribute<ExportCodeFixProviderAttribute>();
 
 		Assert.False(attribute is null, "Missing 'ExportCodeFixProvider' attribute.");
-		Debug.Assert(attribute is not null);
 		Assert.Equal(type.Name, attribute.Name);
 		Assert.Equal(cSharp, attribute.Languages);
 	}
@@ -51,7 +47,6 @@ internal static class TypeExtensions
 		var attribute = type.GetCustomAttribute<ExportCodeRefactoringProviderAttribute>();
 
 		Assert.False(attribute is null, "Missing 'ExportCodeRefactoringProvider' attribute.");
-		Debug.Assert(attribute is not null);
 		Assert.Equal(type.Name, attribute.Name);
 		Assert.Equal(cSharp, attribute.Languages);
 	}

--- a/source/test/F0.CodeAnalysis.Testing/F0.CodeAnalysis.Testing.csproj
+++ b/source/test/F0.CodeAnalysis.Testing/F0.CodeAnalysis.Testing.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ImplicitUsings)' == 'true' Or '$(ImplicitUsings)' == 'enable'">


### PR DESCRIPTION
from https://github.com/Flash0ver/F0.Analyzers/pull/107#discussion_r1342507361

replace
`Debug.Assert(value is not null);`
that are used only for the sake of suppressing nullable warnings
(because `Debug.Assert` has a nullable annotation)